### PR TITLE
Handle pod delete with non-existent IPs

### DIFF
--- a/cmd/whereabouts.go
+++ b/cmd/whereabouts.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-    "strings"
 	"github.com/containernetworking/cni/pkg/skel"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
@@ -79,8 +78,9 @@ func cmdDel(args *skel.CmdArgs) error {
 
 	_, err = storage.IPManagement(types.Deallocate, *ipamConf, args.ContainerID)
 	if err != nil {
-		if (strings.Contains(fmt.Sprintf("%s", err), "Did not find reserved IP for container")) {
-			logging.Debugf("Cannot deallocate IP, it might not have been assigned by us. %s", err)
+		re, ok := err.(*types.IPNotFoundError)
+		if ok {
+			logging.Debugf("Cannot deallocate IP, it might not have been assigned by us, so ignoring. %s", re)
 		} else {
 			logging.Errorf("Error deallocating IP: %s", err)
 			return fmt.Errorf("Error deallocating IP: %s", err)

--- a/cmd/whereabouts.go
+++ b/cmd/whereabouts.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-
+    "strings"
 	"github.com/containernetworking/cni/pkg/skel"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
@@ -79,8 +79,12 @@ func cmdDel(args *skel.CmdArgs) error {
 
 	_, err = storage.IPManagement(types.Deallocate, *ipamConf, args.ContainerID)
 	if err != nil {
-		logging.Errorf("Error deallocating IP: %s", err)
-		return fmt.Errorf("Error deallocating IP: %s", err)
+		if (strings.Contains(fmt.Sprintf("%s", err), "Did not find reserved IP for container")) {
+			logging.Debugf("Cannot deallocate IP, it might not have been assigned by us. %s", err)
+		} else {
+			logging.Errorf("Error deallocating IP: %s", err)
+			return fmt.Errorf("Error deallocating IP: %s", err)
+		}
 	}
 
 	return nil

--- a/pkg/allocate/allocate.go
+++ b/pkg/allocate/allocate.go
@@ -1,6 +1,7 @@
 package allocate
 
 import (
+	//"errors"
 	"fmt"
 	"github.com/dougbtv/whereabouts/pkg/logging"
 	"github.com/dougbtv/whereabouts/pkg/types"
@@ -47,7 +48,9 @@ func IterateForDeallocation(reservelist []types.IPReservation, containerID strin
 
 	// Check if it's a valid index
 	if foundidx < 0 {
-		return reservelist, fmt.Errorf("Did not find reserved IP for container %v", containerID)
+		return reservelist, &types.IPNotFoundError {
+			ContainerID: containerID,
+		}
 	}
 
 	updatedreservelist := removeIdxFromSlice(reservelist, foundidx)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -2,7 +2,7 @@ package types
 
 import (
 	"net"
-
+    "fmt"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 )
 
@@ -79,3 +79,13 @@ const (
 	// Deallocate operation identifier
 	Deallocate = 1
 )
+
+
+// IPNotFoundError represents an error finding a specific IP during the deallocation process for a container.
+type IPNotFoundError struct {
+	ContainerID string
+}
+
+func (e *IPNotFoundError) Error() string {
+	return fmt.Sprintf("Did not find reserved IP for container %v", e.ContainerID)
+}


### PR DESCRIPTION
This patch makes whereabouts pods deployed as ds to use
hostNetwork by default. This is helpful as CNI and core
infra components use hostnetwork and hence avoid issues
such as fault in CNI config etc and also making debugging
much easier.