### PR TITLE
Add leader election

### DIFF
--- a/cmd/whereabouts.go
+++ b/cmd/whereabouts.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/containernetworking/cni/pkg/skel"
@@ -39,7 +40,14 @@ func cmdAdd(args *skel.CmdArgs) error {
 	result.Routes = ipamConf.Routes
 
 	logging.Debugf("Beginning IPAM for ContainerID: %v", args.ContainerID)
-	newip, err := storage.IPManagement(types.Allocate, *ipamConf, args.ContainerID, getPodRef(args.Args))
+	var newip net.IPNet
+
+	switch ipamConf.Datastore {
+	case types.DatastoreETCD:
+		newip, err = storage.IPManagementEtcd(types.Allocate, *ipamConf, args.ContainerID, getPodRef(args.Args))
+	case types.DatastoreKubernetes:
+		newip, err = storage.IPManagementKubernetes(types.Allocate, *ipamConf, args.ContainerID, getPodRef(args.Args))
+	}
 	if err != nil {
 		logging.Errorf("Error at storage engine: %s", err)
 		return fmt.Errorf("Error at storage engine: %w", err)
@@ -78,7 +86,12 @@ func cmdDel(args *skel.CmdArgs) error {
 	logging.Debugf("DEL - IPAM configuration successfully read: %+v", filterConf(*ipamConf))
 	logging.Debugf("ContainerID: %v", args.ContainerID)
 
-	_, err = storage.IPManagement(types.Deallocate, *ipamConf, args.ContainerID, getPodRef(args.Args))
+	switch ipamConf.Datastore {
+	case types.DatastoreETCD:
+		_, err = storage.IPManagementEtcd(types.Deallocate, *ipamConf, args.ContainerID, getPodRef(args.Args))
+	case types.DatastoreKubernetes:
+		_, err = storage.IPManagementKubernetes(types.Deallocate, *ipamConf, args.ContainerID, getPodRef(args.Args))
+	}
 	if err != nil {
 		logging.Verbosef("WARNING: Problem deallocating IP: %s", err)
 		// return fmt.Errorf("Error deallocating IP: %s", err)

--- a/doc/daemonset-install.yaml
+++ b/doc/daemonset-install.yaml
@@ -35,6 +35,12 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - '*'
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,6 +46,8 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*types.IPAMConfig, string, er
 	if err := cnitypes.LoadArgs(envArgs, &args); err != nil {
 		return nil, "", fmt.Errorf("LoadArgs - CNI Args Parsing Error: %s", err)
 	}
+	n.IPAM.PodName = string(args.K8S_POD_NAME)
+	n.IPAM.PodNamespace = string(args.K8S_POD_NAMESPACE)
 
 	// Once we have our basics, let's look for our (optional) configuration file
 	confdirs := []string{"/etc/kubernetes/cni/net.d/whereabouts.d/whereabouts.conf", "/etc/cni/net.d/whereabouts.d/whereabouts.conf"}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -171,6 +171,18 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*types.IPAMConfig, string, er
 		return nil, "", err
 	}
 
+	if n.IPAM.LeaderLeaseDuration == 0 {
+		n.IPAM.LeaderLeaseDuration = types.DefaultLeaderLeaseDuration
+	}
+
+	if n.IPAM.LeaderRenewDeadline == 0 {
+		n.IPAM.LeaderRenewDeadline = types.DefaultLeaderRenewDeadline
+	}
+
+	if n.IPAM.LeaderRetryPeriod == 0 {
+		n.IPAM.LeaderRetryPeriod = types.DefaultLeaderRetryPeriod
+	}
+
 	// Copy net name into IPAM so not to drag Net struct around
 	n.IPAM.Name = n.Name
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -43,6 +43,9 @@ var _ = Describe("Allocation operations", func() {
 		Expect(ipamconfig.RangeStart).To(Equal(net.ParseIP("192.168.1.5")))
 		Expect(ipamconfig.RangeEnd).To(Equal(net.ParseIP("192.168.1.25")))
 		Expect(ipamconfig.Gateway).To(Equal(net.ParseIP("192.168.10.1")))
+		Expect(ipamconfig.LeaderLeaseDuration).To(Equal(1500))
+		Expect(ipamconfig.LeaderRenewDeadline).To(Equal(1000))
+		Expect(ipamconfig.LeaderRetryPeriod).To(Equal(500))
 
 	})
 
@@ -71,7 +74,10 @@ var _ = Describe("Allocation operations", func() {
         "type": "whereabouts",
         "range": "192.168.2.230/24",
         "range_start": "192.168.2.223",
-        "gateway": "192.168.10.1"
+        "gateway": "192.168.10.1",
+        "leader_lease_duration": 3000,
+        "leader_renew_deadline": 2000,
+        "leader_retry_period": 1000
       }
       }`
 
@@ -85,6 +91,10 @@ var _ = Describe("Allocation operations", func() {
 		Expect(ipamconfig.Gateway).To(Equal(net.ParseIP("192.168.10.1")))
 		Expect(ipamconfig.Datastore).To(Equal("kubernetes"))
 		Expect(ipamconfig.Kubernetes.KubeConfigPath).To(Equal("/etc/cni/net.d/whereabouts.d/whereabouts.kubeconfig"))
+
+		Expect(ipamconfig.LeaderLeaseDuration).To(Equal(3000))
+		Expect(ipamconfig.LeaderRenewDeadline).To(Equal(2000))
+		Expect(ipamconfig.LeaderRetryPeriod).To(Equal(1000))
 
 	})
 

--- a/pkg/storage/etcd.go
+++ b/pkg/storage/etcd.go
@@ -10,6 +10,8 @@ import (
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/coreos/etcd/pkg/transport"
+	"github.com/dougbtv/whereabouts/pkg/allocate"
+	"github.com/dougbtv/whereabouts/pkg/logging"
 	"github.com/dougbtv/whereabouts/pkg/types"
 )
 
@@ -136,4 +138,91 @@ func (p *ETCDIPPool) Update(ctx context.Context, reservations []types.IPReservat
 	}
 	_, err := p.kv.Put(ctx, fmt.Sprintf("%s/%s", whereaboutsPrefix, p.ipRange), strings.Join(raw, "\n"))
 	return err
+}
+
+// IPManagement manages ip allocation and deallocation from a storage perspective
+func IPManagementEtcd(mode int, ipamConf types.IPAMConfig, containerID string, podRef string) (net.IPNet, error) {
+
+	logging.Debugf("IPManagement -- mode: %v / host: %v / containerID: %v / podRef: %v", mode, ipamConf.EtcdHost, containerID, podRef)
+
+	var newip net.IPNet
+	// Skip invalid modes
+	switch mode {
+	case types.Allocate, types.Deallocate:
+	default:
+		return newip, fmt.Errorf("Got an unknown mode passed to IPManagement: %v", mode)
+	}
+
+	var ipam Store
+	var pool IPPool
+	var err error
+	switch ipamConf.Datastore {
+	case types.DatastoreETCD:
+		ipam, err = NewETCDIPAM(ipamConf)
+	case types.DatastoreKubernetes:
+		ipam, err = NewKubernetesIPAM(containerID, ipamConf)
+	}
+	if err != nil {
+		logging.Errorf("IPAM %s client initialization error: %v", ipamConf.Datastore, err)
+		return newip, fmt.Errorf("IPAM %s client initialization error: %v", ipamConf.Datastore, err)
+	}
+	defer ipam.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+
+	// Check our connectivity first
+	if err := ipam.Status(ctx); err != nil {
+		logging.Errorf("IPAM connectivity error: %v", err)
+		return newip, err
+	}
+
+	// handle the ip add/del until successful
+RETRYLOOP:
+	for j := 0; j < DatastoreRetries; j++ {
+		select {
+		case <-ctx.Done():
+			return newip, nil
+		default:
+			// retry the IPAM loop if the context has not been cancelled
+		}
+
+		pool, err = ipam.GetIPPool(ctx, ipamConf.Range)
+		if err != nil {
+			logging.Errorf("IPAM error reading pool allocations (attempt: %d): %v", j, err)
+			if e, ok := err.(temporary); ok && e.Temporary() {
+				continue
+			}
+			return newip, err
+		}
+
+		reservelist := pool.Allocations()
+		var updatedreservelist []types.IPReservation
+		switch mode {
+		case types.Allocate:
+			newip, updatedreservelist, err = allocate.AssignIP(ipamConf, reservelist, containerID, podRef)
+			if err != nil {
+				logging.Errorf("Error assigning IP: %v", err)
+				return newip, err
+			}
+		case types.Deallocate:
+			updatedreservelist, err = allocate.DeallocateIP(ipamConf.Range, reservelist, containerID)
+			if err != nil {
+				logging.Errorf("Error deallocating IP: %v", err)
+				return newip, err
+			}
+		}
+
+		err = pool.Update(ctx, updatedreservelist)
+		if err != nil {
+			logging.Errorf("IPAM error updating pool (attempt: %d): %v", j, err)
+			if e, ok := err.(temporary); ok && e.Temporary() {
+				continue
+			}
+			break RETRYLOOP
+		}
+		break RETRYLOOP
+	}
+
+	return newip, err
 }

--- a/pkg/storage/kubernetes.go
+++ b/pkg/storage/kubernetes.go
@@ -7,6 +7,12 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 
 	"github.com/dougbtv/whereabouts/pkg/allocate"
 	whereaboutsv1alpha1 "github.com/dougbtv/whereabouts/pkg/api/v1alpha1"
@@ -41,6 +47,11 @@ func NewKubernetesIPAM(containerID string, ipamConf whereaboutstypes.IPAMConfig)
 		return nil, err
 	}
 
+	clientSet, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
 	var namespace string
 	if cfg, err := clientcmd.LoadFromFile(ipamConf.Kubernetes.KubeConfigPath); err != nil {
 		return nil, err
@@ -57,12 +68,13 @@ func NewKubernetesIPAM(containerID string, ipamConf whereaboutstypes.IPAMConfig)
 	if err != nil {
 		return nil, err
 	}
-	return &KubernetesIPAM{c, ipamConf, containerID, namespace, DatastoreRetries}, nil
+	return &KubernetesIPAM{c, clientSet, ipamConf, containerID, namespace, DatastoreRetries}, nil
 }
 
 // KubernetesIPAM manages ip blocks in an kubernetes CRD backend
 type KubernetesIPAM struct {
 	client      client.Client
+	clientSet   *kubernetes.Clientset
 	config      whereaboutstypes.IPAMConfig
 	containerID string
 	namespace   string
@@ -226,4 +238,201 @@ func (t *temporaryError) Temporary() bool {
 
 type temporary interface {
 	Temporary() bool
+}
+
+// newLeaderElector creates a new leaderelection.LeaderElector and associated
+// channels by which to observe elections and depositions.
+func newLeaderElector(clientset *kubernetes.Clientset, namespace string, podNamespace string, podID string) (*leaderelection.LeaderElector, chan struct{}, chan struct{}) {
+	//log.WithField("context", "leaderelection")
+	// leaderOK will block gRPC startup until it's closed.
+	leaderOK := make(chan struct{})
+	// deposed is closed by the leader election callback when
+	// we are deposed as leader so that we can clean up.
+	deposed := make(chan struct{})
+
+	var rl = &resourcelock.LeaseLock{
+		LeaseMeta: metav1.ObjectMeta{
+			Name:      "whereabouts",
+			Namespace: namespace,
+		},
+		Client: clientset.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity: fmt.Sprintf("%s/%s", podNamespace, podID),
+		},
+	}
+
+	// Make the leader elector, ready to be used in the Workgroup.
+	le, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
+		Lock:          rl,
+		LeaseDuration: 1500 * time.Millisecond,
+		RenewDeadline: 1000 * time.Millisecond,
+		RetryPeriod:   500 * time.Millisecond,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(_ context.Context) {
+				logging.Debugf("OnStartedLeading() called")
+				close(leaderOK)
+			},
+			OnStoppedLeading: func() {
+				logging.Debugf("OnStoppedLeading() called")
+				// The context being canceled will trigger a handler that will
+				// deal with being deposed.
+				close(deposed)
+			},
+		},
+	})
+	if err != nil {
+		logging.Errorf("Failed to create leader elector: %v", err)
+		return nil, leaderOK, deposed
+	}
+	return le, leaderOK, deposed
+}
+
+/*
+ */
+// IPManagement manages ip allocation and deallocation from a storage perspective
+func IPManagementKubernetes(mode int, ipamConf whereaboutstypes.IPAMConfig, containerID string, podRef string) (net.IPNet, error) {
+	var newip net.IPNet
+
+	ipam, err := NewKubernetesIPAM(containerID, ipamConf)
+	if err != nil {
+		return newip, logging.Errorf("IPAM %s client initialization error: %v", ipamConf.Datastore, err)
+	}
+	defer ipam.Close()
+
+	if ipamConf.PodName == "" {
+		return newip, fmt.Errorf("IPAM %s client initialization error: no pod name", ipamConf.Datastore)
+	}
+
+	// setup leader election
+	le, leader, deposed := newLeaderElector(ipam.clientSet, ipam.namespace, ipamConf.PodNamespace, ipamConf.PodName)
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	stopM := make(chan struct{})
+	result := make(chan error, 2)
+
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stopM:
+				logging.Debugf("Stopped leader election")
+				result <- nil
+				return
+			case <-leader:
+				logging.Debugf("Elected as leader, do processing")
+				newip, err = IPManagementKubernetesUpdate(mode, ipam, ipamConf, containerID, podRef)
+				stopM <- struct{}{}
+				return
+			case <-deposed:
+				logging.Debugf("Deposed as leader, shutting down")
+				result <- nil
+				return
+			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithCancel(context.Background())
+		res := make(chan error)
+
+		go func() {
+			logging.Debugf("Started leader election")
+			le.Run(ctx)
+			logging.Debugf("Finished leader election")
+			res <- nil
+		}()
+
+		// wait for stop
+		<-stopM
+		// cancel fn(ctx)
+		cancel()
+		result <- (<-res)
+	}()
+
+	wg.Wait()
+	close(stopM)
+	logging.Debugf("IPManagementKubernetes: %v, %v", newip, err)
+	return newip, err
+}
+
+func IPManagementKubernetesUpdate(mode int, ipam *KubernetesIPAM, ipamConf whereaboutstypes.IPAMConfig, containerID string, podRef string) (net.IPNet, error) {
+	logging.Debugf("IPManagement -- mode: %v / containerID: %v / podRef: %v", mode, containerID, podRef)
+
+	//XXX
+	logging.Debugf("XXX wait for 10 sec")
+	time.Sleep(time.Second * 10)
+	now := time.Now()
+
+	var newip net.IPNet
+	// Skip invalid modes
+	switch mode {
+	case whereaboutstypes.Allocate, whereaboutstypes.Deallocate:
+	default:
+		return newip, fmt.Errorf("Got an unknown mode passed to IPManagement: %v", mode)
+	}
+
+	var pool IPPool
+	var err error
+
+	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	defer cancel()
+
+	// Check our connectivity first
+	if err := ipam.Status(ctx); err != nil {
+		logging.Errorf("IPAM connectivity error: %v", err)
+		return newip, err
+	}
+
+	// handle the ip add/del until successful
+RETRYLOOP:
+	for j := 0; j < DatastoreRetries; j++ {
+		select {
+		case <-ctx.Done():
+			return newip, nil
+		default:
+			// retry the IPAM loop if the context has not been cancelled
+		}
+
+		pool, err = ipam.GetIPPool(ctx, ipamConf.Range)
+		if err != nil {
+			logging.Errorf("IPAM error reading pool allocations (attempt: %d): %v", j, err)
+			if e, ok := err.(temporary); ok && e.Temporary() {
+				continue
+			}
+			return newip, err
+		}
+
+		reservelist := pool.Allocations()
+		var updatedreservelist []whereaboutstypes.IPReservation
+		switch mode {
+		case whereaboutstypes.Allocate:
+			newip, updatedreservelist, err = allocate.AssignIP(ipamConf, reservelist, containerID, podRef)
+			if err != nil {
+				logging.Errorf("Error assigning IP: %v", err)
+				return newip, err
+			}
+		case whereaboutstypes.Deallocate:
+			updatedreservelist, err = allocate.DeallocateIP(ipamConf.Range, reservelist, containerID)
+			if err != nil {
+				logging.Errorf("Error deallocating IP: %v", err)
+				return newip, err
+			}
+		}
+
+		err = pool.Update(ctx, updatedreservelist)
+		if err != nil {
+			logging.Errorf("IPAM error updating pool (attempt: %d): %v", j, err)
+			if e, ok := err.(temporary); ok && e.Temporary() {
+				continue
+			}
+			break RETRYLOOP
+		}
+		break RETRYLOOP
+	}
+
+	//XXX
+	logging.Debugf("Took: %vms\n", time.Since(now).Milliseconds())
+	return newip, err
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -2,12 +2,8 @@ package storage
 
 import (
 	"context"
-	"fmt"
-	"net"
 	"time"
 
-	"github.com/dougbtv/whereabouts/pkg/allocate"
-	"github.com/dougbtv/whereabouts/pkg/logging"
 	"github.com/dougbtv/whereabouts/pkg/types"
 )
 
@@ -30,91 +26,4 @@ type Store interface {
 	GetIPPool(ctx context.Context, ipRange string) (IPPool, error)
 	Status(ctx context.Context) error
 	Close() error
-}
-
-// IPManagement manages ip allocation and deallocation from a storage perspective
-func IPManagement(mode int, ipamConf types.IPAMConfig, containerID string, podRef string) (net.IPNet, error) {
-
-	logging.Debugf("IPManagement -- mode: %v / host: %v / containerID: %v / podRef: %v", mode, ipamConf.EtcdHost, containerID, podRef)
-
-	var newip net.IPNet
-	// Skip invalid modes
-	switch mode {
-	case types.Allocate, types.Deallocate:
-	default:
-		return newip, fmt.Errorf("Got an unknown mode passed to IPManagement: %v", mode)
-	}
-
-	var ipam Store
-	var pool IPPool
-	var err error
-	switch ipamConf.Datastore {
-	case types.DatastoreETCD:
-		ipam, err = NewETCDIPAM(ipamConf)
-	case types.DatastoreKubernetes:
-		ipam, err = NewKubernetesIPAM(containerID, ipamConf)
-	}
-	if err != nil {
-		logging.Errorf("IPAM %s client initialization error: %v", ipamConf.Datastore, err)
-		return newip, fmt.Errorf("IPAM %s client initialization error: %v", ipamConf.Datastore, err)
-	}
-	defer ipam.Close()
-
-	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
-	defer cancel()
-
-	// Check our connectivity first
-	if err := ipam.Status(ctx); err != nil {
-		logging.Errorf("IPAM connectivity error: %v", err)
-		return newip, err
-	}
-
-	// handle the ip add/del until successful
-RETRYLOOP:
-	for j := 0; j < DatastoreRetries; j++ {
-		select {
-		case <-ctx.Done():
-			return newip, nil
-		default:
-			// retry the IPAM loop if the context has not been cancelled
-		}
-
-		pool, err = ipam.GetIPPool(ctx, ipamConf.Range)
-		if err != nil {
-			logging.Errorf("IPAM error reading pool allocations (attempt: %d): %v", j, err)
-			if e, ok := err.(temporary); ok && e.Temporary() {
-				continue
-			}
-			return newip, err
-		}
-
-		reservelist := pool.Allocations()
-		var updatedreservelist []types.IPReservation
-		switch mode {
-		case types.Allocate:
-			newip, updatedreservelist, err = allocate.AssignIP(ipamConf, reservelist, containerID, podRef)
-			if err != nil {
-				logging.Errorf("Error assigning IP: %v", err)
-				return newip, err
-			}
-		case types.Deallocate:
-			updatedreservelist, err = allocate.DeallocateIP(ipamConf.Range, reservelist, containerID)
-			if err != nil {
-				logging.Errorf("Error deallocating IP: %v", err)
-				return newip, err
-			}
-		}
-
-		err = pool.Update(ctx, updatedreservelist)
-		if err != nil {
-			logging.Errorf("IPAM error updating pool (attempt: %d): %v", j, err)
-			if e, ok := err.(temporary); ok && e.Temporary() {
-				continue
-			}
-			break RETRYLOOP
-		}
-		break RETRYLOOP
-	}
-
-	return newip, err
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -8,8 +8,11 @@ import (
 
 // Datastore types
 const (
-	DatastoreETCD       = "etcd"
-	DatastoreKubernetes = "kubernetes"
+	DatastoreETCD              = "etcd"
+	DatastoreKubernetes        = "kubernetes"
+	DefaultLeaderLeaseDuration = 1500
+	DefaultLeaderRenewDeadline = 1000
+	DefaultLeaderRetryPeriod   = 500
 )
 
 // Net is The top-level network config - IPAM plugins are passed the full configuration
@@ -22,30 +25,33 @@ type Net struct {
 
 // IPAMConfig describes the expected json configuration for this plugin
 type IPAMConfig struct {
-	Name              string
-	Type              string            `json:"type"`
-	Routes            []*cnitypes.Route `json:"routes"`
-	Datastore         string            `json:"datastore"`
-	Addresses         []Address         `json:"addresses,omitempty"`
-	OmitRanges        []string          `json:"exclude,omitempty"`
-	DNS               cnitypes.DNS      `json:"dns"`
-	Range             string            `json:"range"`
-	RangeStart        net.IP            `json:"range_start,omitempty"`
-	RangeEnd          net.IP            `json:"range_end,omitempty"`
-	GatewayStr        string            `json:"gateway"`
-	EtcdHost          string            `json:"etcd_host,omitempty"`
-	EtcdUsername      string            `json:"etcd_username,omitempty"`
-	EtcdPassword      string            `json:"etcd_password,omitempty"`
-	EtcdKeyFile       string            `json:"etcd_key_file,omitempty"`
-	EtcdCertFile      string            `json:"etcd_cert_file,omitempty"`
-	EtcdCACertFile    string            `json:"etcd_ca_cert_file,omitempty"`
-	LogFile           string            `json:"log_file"`
-	LogLevel          string            `json:"log_level"`
-	Gateway           net.IP
-	Kubernetes        KubernetesConfig `json:"kubernetes,omitempty"`
-	ConfigurationPath string           `json:"configuration_path"`
-	PodName           string
-	PodNamespace      string
+	Name                string
+	Type                string            `json:"type"`
+	Routes              []*cnitypes.Route `json:"routes"`
+	Datastore           string            `json:"datastore"`
+	Addresses           []Address         `json:"addresses,omitempty"`
+	OmitRanges          []string          `json:"exclude,omitempty"`
+	DNS                 cnitypes.DNS      `json:"dns"`
+	Range               string            `json:"range"`
+	RangeStart          net.IP            `json:"range_start,omitempty"`
+	RangeEnd            net.IP            `json:"range_end,omitempty"`
+	GatewayStr          string            `json:"gateway"`
+	EtcdHost            string            `json:"etcd_host,omitempty"`
+	EtcdUsername        string            `json:"etcd_username,omitempty"`
+	EtcdPassword        string            `json:"etcd_password,omitempty"`
+	EtcdKeyFile         string            `json:"etcd_key_file,omitempty"`
+	EtcdCertFile        string            `json:"etcd_cert_file,omitempty"`
+	EtcdCACertFile      string            `json:"etcd_ca_cert_file,omitempty"`
+	LeaderLeaseDuration int               `json:"leader_lease_duration,omitempty"`
+	LeaderRenewDeadline int               `json:"leader_renew_deadline,omitempty"`
+	LeaderRetryPeriod   int               `json:"leader_retry_period,omitempty"`
+	LogFile             string            `json:"log_file"`
+	LogLevel            string            `json:"log_level"`
+	Gateway             net.IP
+	Kubernetes          KubernetesConfig `json:"kubernetes,omitempty"`
+	ConfigurationPath   string           `json:"configuration_path"`
+	PodName             string
+	PodNamespace        string
 }
 
 // IPAMEnvArgs are the environment vars we expect

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -44,13 +44,18 @@ type IPAMConfig struct {
 	Gateway           net.IP
 	Kubernetes        KubernetesConfig `json:"kubernetes,omitempty"`
 	ConfigurationPath string           `json:"configuration_path"`
+	PodName           string
+	PodNamespace      string
 }
 
 // IPAMEnvArgs are the environment vars we expect
 type IPAMEnvArgs struct {
 	cnitypes.CommonArgs
-	IP      cnitypes.UnmarshallableString `json:"ip,omitempty"`
-	GATEWAY cnitypes.UnmarshallableString `json:"gateway,omitempty"`
+	IP                         cnitypes.UnmarshallableString `json:"ip,omitempty"`
+	GATEWAY                    cnitypes.UnmarshallableString `json:"gateway,omitempty"`
+	K8S_POD_NAME               cnitypes.UnmarshallableString //revive:disable-line
+	K8S_POD_NAMESPACE          cnitypes.UnmarshallableString //revive:disable-line
+	K8S_POD_INFRA_CONTAINER_ID cnitypes.UnmarshallableString //revive:disable-line
 }
 
 // KubernetesConfig describes the kubernetes-specific configuration details


### PR DESCRIPTION
Uses `k8s.io/client-go/tools/leaderelection` to add leader election to choose a leader during CRD read/write in order to properly handle concurrency before ippools are calculated and modified.