### PR TITLE
replace patch with update api to rewrite IPPool

### DIFF
--- a/cmd/whereabouts.go
+++ b/cmd/whereabouts.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -81,6 +82,10 @@ func cmdDel(args *skel.CmdArgs) error {
 	_, err = storage.IPManagement(types.Deallocate, *ipamConf, args.ContainerID, getPodRef(args.Args))
 	if err != nil {
 		logging.Verbosef("WARNING: Problem deallocating IP: %s", err)
+		// ok to return context deadline error. this makes kubelet/cni would retry for deallocate.
+		if err == context.DeadlineExceeded || strings.Contains(err.Error(), "context deadline exceeded") {
+			return err
+		}
 		// return fmt.Errorf("Error deallocating IP: %s", err)
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -132,9 +132,21 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*types.IPAMConfig, string, er
 		n.IPAM.Datastore = types.DatastoreETCD
 	}
 
-	if n.IPAM.RequestTimeout == 0 {
+	if n.IPAM.AllocateRequestTimeout == 0 {
 		// default to 10s
-		n.IPAM.RequestTimeout = 10
+		n.IPAM.AllocateRequestTimeout = 10
+	}
+
+	if n.IPAM.DeAllocateRequestTimeout == 0 {
+		// default to 10s
+		n.IPAM.DeAllocateRequestTimeout = 10
+	}
+
+	if !strings.EqualFold(n.IPAM.BackOffRetryScheme, "exponential") {
+		if n.IPAM.BackoffLinearStep == 0 {
+			// set backoff step to 500 ms
+			n.IPAM.BackoffLinearStep = 500
+		}
 	}
 
 	var err error

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -132,6 +132,11 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*types.IPAMConfig, string, er
 		n.IPAM.Datastore = types.DatastoreETCD
 	}
 
+	if n.IPAM.RequestTimeout == 0 {
+		// default to 10s
+		n.IPAM.RequestTimeout = 10
+	}
+
 	var err error
 	storageError := "You have not configured the storage engine (looks like you're using an invalid `%s` parameter in your config)"
 	switch n.IPAM.Datastore {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -71,9 +71,8 @@ RETRYLOOP:
 	for j := 0; j < DatastoreRetries; j++ {
 		select {
 		case <-ctx.Done():
-			// return last available newip and err
-			logging.Errorf("context is done for ip pool %s, returning last ip %s: error %v", ipamConf.Range, newip.String(), err)
-			return newip, err
+			// return last available newip and context.DeadlineExceeded error
+			return newip, context.DeadlineExceeded
 		default:
 			// retry the IPAM loop if the context has not been cancelled
 		}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -109,6 +109,7 @@ RETRYLOOP:
 		if err != nil {
 			logging.Errorf("IPAM error updating pool (attempt: %d): %v", j, err)
 			if e, ok := err.(temporary); ok && e.Temporary() {
+				logging.Errorf("IPAM error is temporary, retrying")
 				continue
 			}
 			break RETRYLOOP

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -12,9 +12,6 @@ import (
 )
 
 var (
-	// RequestTimeout defines how long the context timesout in
-	RequestTimeout = 10 * time.Second
-
 	// DatastoreRetries defines how many retries are attempted when updating the Pool
 	DatastoreRetries = 100
 )
@@ -60,7 +57,7 @@ func IPManagement(mode int, ipamConf types.IPAMConfig, containerID string, podRe
 	}
 	defer ipam.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), RequestTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(ipamConf.RequestTimeout)*time.Second)
 	defer cancel()
 
 	// Check our connectivity first

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -44,6 +44,7 @@ type IPAMConfig struct {
 	Gateway           net.IP
 	Kubernetes        KubernetesConfig `json:"kubernetes,omitempty"`
 	ConfigurationPath string           `json:"configuration_path"`
+	RequestTimeout    int              `json:"request_timeout"`
 }
 
 // IPAMEnvArgs are the environment vars we expect

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -22,29 +22,32 @@ type Net struct {
 
 // IPAMConfig describes the expected json configuration for this plugin
 type IPAMConfig struct {
-	Name              string
-	Type              string            `json:"type"`
-	Routes            []*cnitypes.Route `json:"routes"`
-	Datastore         string            `json:"datastore"`
-	Addresses         []Address         `json:"addresses,omitempty"`
-	OmitRanges        []string          `json:"exclude,omitempty"`
-	DNS               cnitypes.DNS      `json:"dns"`
-	Range             string            `json:"range"`
-	RangeStart        net.IP            `json:"range_start,omitempty"`
-	RangeEnd          net.IP            `json:"range_end,omitempty"`
-	GatewayStr        string            `json:"gateway"`
-	EtcdHost          string            `json:"etcd_host,omitempty"`
-	EtcdUsername      string            `json:"etcd_username,omitempty"`
-	EtcdPassword      string            `json:"etcd_password,omitempty"`
-	EtcdKeyFile       string            `json:"etcd_key_file,omitempty"`
-	EtcdCertFile      string            `json:"etcd_cert_file,omitempty"`
-	EtcdCACertFile    string            `json:"etcd_ca_cert_file,omitempty"`
-	LogFile           string            `json:"log_file"`
-	LogLevel          string            `json:"log_level"`
-	Gateway           net.IP
-	Kubernetes        KubernetesConfig `json:"kubernetes,omitempty"`
-	ConfigurationPath string           `json:"configuration_path"`
-	RequestTimeout    int              `json:"request_timeout"`
+	Name                     string
+	Type                     string            `json:"type"`
+	Routes                   []*cnitypes.Route `json:"routes"`
+	Datastore                string            `json:"datastore"`
+	Addresses                []Address         `json:"addresses,omitempty"`
+	OmitRanges               []string          `json:"exclude,omitempty"`
+	DNS                      cnitypes.DNS      `json:"dns"`
+	Range                    string            `json:"range"`
+	RangeStart               net.IP            `json:"range_start,omitempty"`
+	RangeEnd                 net.IP            `json:"range_end,omitempty"`
+	GatewayStr               string            `json:"gateway"`
+	EtcdHost                 string            `json:"etcd_host,omitempty"`
+	EtcdUsername             string            `json:"etcd_username,omitempty"`
+	EtcdPassword             string            `json:"etcd_password,omitempty"`
+	EtcdKeyFile              string            `json:"etcd_key_file,omitempty"`
+	EtcdCertFile             string            `json:"etcd_cert_file,omitempty"`
+	EtcdCACertFile           string            `json:"etcd_ca_cert_file,omitempty"`
+	LogFile                  string            `json:"log_file"`
+	LogLevel                 string            `json:"log_level"`
+	Gateway                  net.IP
+	Kubernetes               KubernetesConfig `json:"kubernetes,omitempty"`
+	ConfigurationPath        string           `json:"configuration_path"`
+	AllocateRequestTimeout   int              `json:"allocate_request_timeout"`
+	DeAllocateRequestTimeout int              `json:"deallocate_request_timeout"`
+	BackOffRetryScheme       string           `json:"backoff_scheme"`
+	BackoffLinearStep        int              `json:"linear_step"`
 }
 
 // IPAMEnvArgs are the environment vars we expect

--- a/script/install-cni.sh
+++ b/script/install-cni.sh
@@ -20,6 +20,7 @@ mkdir -p $CNI_CONF_DIR/whereabouts.d
 WHEREABOUTS_KUBECONFIG=$CNI_CONF_DIR/whereabouts.d/whereabouts.kubeconfig
 WHEREABOUTS_FLATFILE=$CNI_CONF_DIR/whereabouts.d/whereabouts.conf
 WHEREABOUTS_KUBECONFIG_LITERAL=$(echo "$WHEREABOUTS_KUBECONFIG" | sed -e s'|/host||')
+WHEREABOUTS_REQUEST_TIMEOUT=10
 
 # ------------------------------- Generate a "kube-config"
 SERVICE_ACCOUNT_PATH=/var/run/secrets/kubernetes.io/serviceaccount
@@ -100,6 +101,7 @@ EOF
   cat > $WHEREABOUTS_FLATFILE <<EOF
 {
   "datastore": "kubernetes",
+  "request_timeout": $WHEREABOUTS_REQUEST_TIMEOUT,
   "kubernetes": {
     "kubeconfig": "${WHEREABOUTS_KUBECONFIG_LITERAL}"
   }

--- a/script/install-cni.sh
+++ b/script/install-cni.sh
@@ -20,7 +20,6 @@ mkdir -p $CNI_CONF_DIR/whereabouts.d
 WHEREABOUTS_KUBECONFIG=$CNI_CONF_DIR/whereabouts.d/whereabouts.kubeconfig
 WHEREABOUTS_FLATFILE=$CNI_CONF_DIR/whereabouts.d/whereabouts.conf
 WHEREABOUTS_KUBECONFIG_LITERAL=$(echo "$WHEREABOUTS_KUBECONFIG" | sed -e s'|/host||')
-WHEREABOUTS_REQUEST_TIMEOUT=10
 
 # ------------------------------- Generate a "kube-config"
 SERVICE_ACCOUNT_PATH=/var/run/secrets/kubernetes.io/serviceaccount
@@ -101,7 +100,6 @@ EOF
   cat > $WHEREABOUTS_FLATFILE <<EOF
 {
   "datastore": "kubernetes",
-  "request_timeout": $WHEREABOUTS_REQUEST_TIMEOUT,
   "kubernetes": {
     "kubeconfig": "${WHEREABOUTS_KUBECONFIG_LITERAL}"
   }


### PR DESCRIPTION
as we noticied patch operation doesn't provide concurrency safety (refer this [link](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/)), replace it with update api to make ip assignment to be atomic.

`TODO: large scale verification is still pending`