### PR TITLE
ippools schema: add podref

### DIFF
--- a/doc/whereabouts.cni.cncf.io_ippools.yaml
+++ b/doc/whereabouts.cni.cncf.io_ippools.yaml
@@ -40,6 +40,8 @@ spec:
                     properties:
                       id:
                         type: string
+                      podref:
+                        type: string
                     required:
                     - id
                     type: object


### PR DESCRIPTION
PR #86 added support for a `podRef` field in the `IPReservation`.
Unfortunately, the IPPools CR was not updated, which causes the
whereabouts installation to miss it.

This commit adds the `podRef` attribute to the CR, as optional.
