### PR TITLE
return context timeout error for deallocate

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -132,6 +132,23 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*types.IPAMConfig, string, er
 		n.IPAM.Datastore = types.DatastoreETCD
 	}
 
+	if n.IPAM.AllocateRequestTimeout == 0 {
+		// default to 10s
+		n.IPAM.AllocateRequestTimeout = 10
+	}
+
+	if n.IPAM.DeAllocateRequestTimeout == 0 {
+		// default to 10s
+		n.IPAM.DeAllocateRequestTimeout = 10
+	}
+
+	if !strings.EqualFold(n.IPAM.BackOffRetryScheme, "exponential") {
+		if n.IPAM.BackoffLinearStep == 0 {
+			// set backoff step to 500 ms
+			n.IPAM.BackoffLinearStep = 500
+		}
+	}
+
 	var err error
 	storageError := "You have not configured the storage engine (looks like you're using an invalid `%s` parameter in your config)"
 	switch n.IPAM.Datastore {

--- a/pkg/storage/kubernetes.go
+++ b/pkg/storage/kubernetes.go
@@ -125,13 +125,13 @@ func (i *KubernetesIPAM) getPool(ctx context.Context, name string, iprange strin
 		pool.Spec.Allocations = make(map[string]whereaboutsv1alpha1.IPAllocation)
 		if err := i.client.Create(ctx, pool); errors.IsAlreadyExists(err) {
 			// the pool was just created -- allow retry
-			return nil, &TemporaryError{err}
+			return nil, &temporaryError{err}
 		} else if err != nil {
 			return nil, fmt.Errorf("k8s create error: %s", err)
 		}
 		// if the pool was created for the first time, trigger another retry of the allocation loop
 		// so all of the metadata / resourceVersions are populated as necessary by the `client.Get` call
-		return nil, &TemporaryError{fmt.Errorf("k8s pool initialized")}
+		return nil, &temporaryError{fmt.Errorf("k8s pool initialized")}
 	} else if err != nil {
 		return nil, fmt.Errorf("k8s get error: %s", err)
 	}
@@ -208,10 +208,22 @@ func (p *KubernetesIPPool) Update(ctx context.Context, reservations []whereabout
 	if err != nil {
 		if errors.IsInvalid(err) {
 			// expect "invalid" errors if any of the jsonpatch "test" Operations fail
-			return &TemporaryError{err}
+			return &temporaryError{err}
 		}
 		return err
 	}
 
 	return nil
+}
+
+type temporaryError struct {
+	error
+}
+
+func (t *temporaryError) Temporary() bool {
+	return true
+}
+
+type temporary interface {
+	Temporary() bool
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -74,7 +74,9 @@ RETRYLOOP:
 	for j := 0; j < DatastoreRetries; j++ {
 		select {
 		case <-ctx.Done():
-			return newip, nil
+			// when context is canceled due to request timeout, then return err as temporary error.
+			// would this be also potential fix for https://github.com/k8snetworkplumbingwg/whereabouts/issues/110 ?
+			return newip, &TemporaryError{err}
 		default:
 			// retry the IPAM loop if the context has not been cancelled
 		}
@@ -82,7 +84,7 @@ RETRYLOOP:
 		pool, err = ipam.GetIPPool(ctx, ipamConf.Range)
 		if err != nil {
 			logging.Errorf("IPAM error reading pool allocations (attempt: %d): %v", j, err)
-			if e, ok := err.(temporary); ok && e.Temporary() {
+			if e, ok := err.(Temporary); ok && e.Temporary() {
 				continue
 			}
 			return newip, err
@@ -108,7 +110,7 @@ RETRYLOOP:
 		err = pool.Update(ctx, updatedreservelist)
 		if err != nil {
 			logging.Errorf("IPAM error updating pool (attempt: %d): %v", j, err)
-			if e, ok := err.(temporary); ok && e.Temporary() {
+			if e, ok := err.(Temporary); ok && e.Temporary() {
 				continue
 			}
 			break RETRYLOOP
@@ -117,4 +119,21 @@ RETRYLOOP:
 	}
 
 	return newip, err
+}
+
+type TemporaryError struct {
+	error
+}
+
+func (t *TemporaryError) Temporary() bool {
+	return true
+}
+
+func (t *TemporaryError) GetCause() error {
+	return t.error
+}
+
+type Temporary interface {
+	Temporary() bool
+	GetCause() error
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -22,28 +22,32 @@ type Net struct {
 
 // IPAMConfig describes the expected json configuration for this plugin
 type IPAMConfig struct {
-	Name              string
-	Type              string            `json:"type"`
-	Routes            []*cnitypes.Route `json:"routes"`
-	Datastore         string            `json:"datastore"`
-	Addresses         []Address         `json:"addresses,omitempty"`
-	OmitRanges        []string          `json:"exclude,omitempty"`
-	DNS               cnitypes.DNS      `json:"dns"`
-	Range             string            `json:"range"`
-	RangeStart        net.IP            `json:"range_start,omitempty"`
-	RangeEnd          net.IP            `json:"range_end,omitempty"`
-	GatewayStr        string            `json:"gateway"`
-	EtcdHost          string            `json:"etcd_host,omitempty"`
-	EtcdUsername      string            `json:"etcd_username,omitempty"`
-	EtcdPassword      string            `json:"etcd_password,omitempty"`
-	EtcdKeyFile       string            `json:"etcd_key_file,omitempty"`
-	EtcdCertFile      string            `json:"etcd_cert_file,omitempty"`
-	EtcdCACertFile    string            `json:"etcd_ca_cert_file,omitempty"`
-	LogFile           string            `json:"log_file"`
-	LogLevel          string            `json:"log_level"`
-	Gateway           net.IP
-	Kubernetes        KubernetesConfig `json:"kubernetes,omitempty"`
-	ConfigurationPath string           `json:"configuration_path"`
+	Name                     string
+	Type                     string            `json:"type"`
+	Routes                   []*cnitypes.Route `json:"routes"`
+	Datastore                string            `json:"datastore"`
+	Addresses                []Address         `json:"addresses,omitempty"`
+	OmitRanges               []string          `json:"exclude,omitempty"`
+	DNS                      cnitypes.DNS      `json:"dns"`
+	Range                    string            `json:"range"`
+	RangeStart               net.IP            `json:"range_start,omitempty"`
+	RangeEnd                 net.IP            `json:"range_end,omitempty"`
+	GatewayStr               string            `json:"gateway"`
+	EtcdHost                 string            `json:"etcd_host,omitempty"`
+	EtcdUsername             string            `json:"etcd_username,omitempty"`
+	EtcdPassword             string            `json:"etcd_password,omitempty"`
+	EtcdKeyFile              string            `json:"etcd_key_file,omitempty"`
+	EtcdCertFile             string            `json:"etcd_cert_file,omitempty"`
+	EtcdCACertFile           string            `json:"etcd_ca_cert_file,omitempty"`
+	LogFile                  string            `json:"log_file"`
+	LogLevel                 string            `json:"log_level"`
+	Gateway                  net.IP
+	Kubernetes               KubernetesConfig `json:"kubernetes,omitempty"`
+	ConfigurationPath        string           `json:"configuration_path"`
+	AllocateRequestTimeout   int              `json:"allocate_request_timeout"`
+	DeAllocateRequestTimeout int              `json:"deallocate_request_timeout"`
+	BackOffRetryScheme       string           `json:"backoff_scheme"`
+	BackoffLinearStep        int              `json:"linear_step"`
 }
 
 // IPAMEnvArgs are the environment vars we expect


### PR DESCRIPTION
return context timeout error back to cni/kubelet in case of pod delete, this would allow kubelet to retry for deallocate and avoids stale ip pool entries in the datastore after pod delete.

context timeout errors (due to default 10s request timeout) are frequently seen in highly scaled setup.

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>