### PR TITLE
build: update openshift build image to golang 1.15

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,14 +1,5 @@
 # This dockerfile is used for building for OpenShift
-FROM openshift/origin-release:rhel-8-golang-1.12 as rhel8
-ADD . /go/src/github.com/dougbtv/whereabouts
-WORKDIR /go/src/github.com/dougbtv/whereabouts
-ENV CGO_ENABLED=1
-ENV GO111MODULE=on
-ENV VERSION=rhel8 COMMIT=unset
-RUN go build -mod vendor -o bin/whereabouts cmd/whereabouts.go
-WORKDIR /
-
-FROM openshift/origin-release:rhel-7-golang-1.12 as rhel7
+FROM openshift/origin-release:golang-1.15 as builder
 ADD . /go/src/github.com/dougbtv/whereabouts
 WORKDIR /go/src/github.com/dougbtv/whereabouts
 ENV CGO_ENABLED=1
@@ -18,12 +9,8 @@ WORKDIR /
 
 FROM openshift/origin-base
 RUN mkdir -p /usr/src/whereabouts/images && \
-       mkdir -p /usr/src/whereabouts/bin && \
-       mkdir -p /usr/src/whereabouts/rhel7/bin && \
-       mkdir -p /usr/src/whereabouts/rhel8/bin
-COPY --from=rhel7 /go/src/github.com/dougbtv/whereabouts/bin/whereabouts /usr/src/whereabouts/rhel7/bin
-COPY --from=rhel7 /go/src/github.com/dougbtv/whereabouts/bin/whereabouts /usr/src/whereabouts/bin
-COPY --from=rhel8 /go/src/github.com/dougbtv/whereabouts/bin/whereabouts /usr/src/whereabouts/rhel8/bin
+       mkdir -p /usr/src/whereabouts/bin
+COPY --from=builder /go/src/github.com/dougbtv/whereabouts/bin/whereabouts /usr/src/whereabouts/bin
 
 LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/whereabouts
 LABEL io.k8s.display-name="Whereabouts CNI" \


### PR DESCRIPTION
This new Dockerfile for openshift was inspired by the multus one,
available at [0].

[0] - https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/deployments/Dockerfile.openshift#L2
