### PR TITLE
propagate context timeout error

### DIFF
--- a/pkg/storage/kubernetes/ipam.go
+++ b/pkg/storage/kubernetes/ipam.go
@@ -433,7 +433,7 @@ RETRYLOOP:
 	for j := 0; j < storage.DatastoreRetries; j++ {
 		select {
 		case <-ctx.Done():
-			return newip, nil
+			return newip, err
 		default:
 			// retry the IPAM loop if the context has not been cancelled
 		}


### PR DESCRIPTION
#141 

When context timeout occurs while updating the ip pool CRD,
error is not returned but allocated IP is returned. This leads
to duplicate IP allocation.

This change fixes the above by returning error.

Signed-off-by: Ravindra Thakur <ravindra.nath.thakur@est.tech>