### PR TITLE
Release lease lock when LE ends

### DIFF
--- a/pkg/storage/kubernetes/ipam.go
+++ b/pkg/storage/kubernetes/ipam.go
@@ -313,6 +313,7 @@ func newLeaderElector(clientset *kubernetes.Clientset, namespace string, podName
 		LeaseDuration: time.Duration(leaseDuration) * time.Millisecond,
 		RenewDeadline: time.Duration(renewDeadline) * time.Millisecond,
 		RetryPeriod:   time.Duration(retryPeriod) * time.Millisecond,
+		ReleaseOnCancel: true,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(_ context.Context) {
 				logging.Debugf("OnStartedLeading() called")


### PR DESCRIPTION
Signed-off-by: Martin Kennelly <mkennell@redhat.com>

Description of feature: https://pkg.go.dev/k8s.io/client-go/tools/leaderelection#LeaderElectionConfig

Enabling this should be ok because we are not interacting with our protected resource (IP Pools) when we end LE.