### PR TITLE
ip-reconciler: Add all non default interfaces to Pod IP list

### DIFF
--- a/pkg/reconciler/wrappedPod.go
+++ b/pkg/reconciler/wrappedPod.go
@@ -71,10 +71,9 @@ func getFlatIPSet(pod v1.Pod) map[string]void {
 			continue
 		}
 
-		if network.Interface[:multusPrefixSize] == multusInterfaceNamePrefix {
-			for _, ip := range network.IPs {
-				ipSet[ip] = empty
-			}
+		for _, ip := range network.IPs {
+			ipSet[ip] = empty
+			logging.Debugf("Added IP %s for pod %s", ip, composePodRef(pod))
 		}
 	}
 	return ipSet

--- a/pkg/reconciler/wrappedPod_test.go
+++ b/pkg/reconciler/wrappedPod_test.go
@@ -114,23 +114,6 @@ var _ = Describe("Pod Wrapper operations", func() {
 			Expect(podSecondaryIPs).To(Equal(map[string]void{"192.168.14.14": {}, "10.10.10.10": {}}))
 		})
 
-		It("should filter out non-multus annotations", func() {
-			secondaryIfacesNetworkStatuses := generateMultusNetworkStatusList("192.168.14.14", "10.10.10.10")
-
-			networkStatus := append(
-				secondaryIfacesNetworkStatuses,
-				generateMultusNetworkStatus("eth0", "network33", "14.15.16.20"))
-			pod := v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: generateMultusNetworkStatusAnnotationFromNetworkStatus(networkStatus...),
-				},
-			}
-
-			podSecondaryIPs := wrapPod(pod).ips
-			Expect(podSecondaryIPs).To(HaveLen(2))
-			Expect(podSecondaryIPs).To(Equal(map[string]void{"192.168.14.14": {}, "10.10.10.10": {}}))
-		})
-
 		It("return an empty list when the network annotations of a pod are invalid", func() {
 			pod := v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This fixes https://github.com/k8snetworkplumbingwg/whereabouts/issues/130

In code below,

```
	for _, network := range networkStatusList {
		// we're only after multus secondary interfaces
		if network.Default {
			continue
		}

		if network.Interface[:multusPrefixSize] == multusInterfaceNamePrefix {
			for _, ip := range network.IPs {
				ipSet[ip] = empty
			}
		}
	}
```

I don't know of any case where there would be a network attachment that isn't default, but not a Multus attachment? The way I understand it, we have a primary CNI (such as Calico, for us). This is implicitly attached to every Pod as "eth0", and in describe Pod, it is always set to default: True

So, is there any case where the Pod would have multiple Networks, and one of them not be Default yet not Multus?

Either way, I don't think this check is correct, as in the Pod's network annotation, it is allowed to change the interface name. At very least there should be some other way to detect Multus interfaces (if simply checking for not default isn't sufficient). For example, see this example: https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/docs/how-to-use.md#launch-pod-with-json-annotation-with-interface.

With my fix, I set Pod's interface to be named "eth1" for my macvlan network. Per the Log I added to ip-reconciler, I can see it's now added the the IPSet for the Pod:

```
xagent@pop-os:~/luigi/samples/macvlan$ kubectl logs ip-reconciler-1632195360-9vgrk -n kube-system
2021-09-21T03:36:07Z [debug] NewReconcileLooper - Kubernetes config file located at: /host/etc/cni/net.d/whereabouts.d/whereabouts.kubeconfig
2021-09-21T03:36:08Z [debug] successfully read the kubernetes configuration file located at: /host/etc/cni/net.d/whereabouts.d/whereabouts.kubeconfig
2021-09-21T03:36:08Z [debug] listing IP pools
2021-09-21T03:36:08Z [debug] **Added IP 10.128.165.230 for pod kube-system/samplepod1**
2021-09-21T03:36:08Z [debug] **Added IP 10.128.165.231 for pod kube-system/samplepod2**
2021-09-21T03:36:08Z [debug] the IP reservation: IP: 10.128.165.230 is reserved for pod: kube-system/samplepod1
2021-09-21T03:36:08Z [debug] pod reference kube-system/samplepod1 matches allocation; Allocation IP: 10.128.165.230; PodIPs: map[10.128.165.230:{}]
2021-09-21T03:36:08Z [debug] the IP reservation: IP: 10.128.165.231 is reserved for pod: kube-system/samplepod2
2021-09-21T03:36:08Z [debug] pod reference kube-system/samplepod2 matches allocation; Allocation IP: 10.128.165.231; PodIPs: map[10.128.165.231:{}]
2021-09-21T03:36:09Z [debug] pod reference kube-system/samplepod1 matches allocation; Allocation IP: 10.128.165.230; PodIPs: map[10.128.165.230:{}]
2021-09-21T03:36:09Z [debug] pod reference kube-system/samplepod2 matches allocation; Allocation IP: 10.128.165.231; PodIPs: map[10.128.165.231:{}]
2021-09-21T03:36:09Z [debug] no IP addresses to cleanup

```

I just removed the entire testcase for this too, as it's called "should filter out non-multus annotations", but to generate it, it calls function "generateMultusNetworkStatus". It just sets a different interface name as "eth0", which is allowed by Multus. 