### PR TITLE
Add label app=whereabouts to ip-reconciler pod template

### DIFF
--- a/doc/crds/ip-reconciler-job.yaml
+++ b/doc/crds/ip-reconciler-job.yaml
@@ -10,6 +10,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            app: whereabouts
         spec:
           containers:
             - name: whereabouts


### PR DESCRIPTION
This will allow excluding the pod that is created in the default
namespace i.e.

    kubectl wait --for=condition=Ready pod --timeout=30s -l app!=whereabouts

Effectively migitating flaking check here: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirtci/676/check-provision-k8s-1.21/1440922688099979264

See https://github.com/kubevirt/kubevirtci/pull/676