### PR TITLE
added sleep-for-race option for IPAM

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,6 +36,7 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*types.IPAMConfig, string, er
 	n := types.Net{
 		IPAM: &types.IPAMConfig{
 			OverlappingRanges: true,
+			SleepForRace:      false,
 		},
 	}
 	if err := json.Unmarshal(bytes, &n); err != nil {

--- a/pkg/storage/kubernetes/ipam.go
+++ b/pkg/storage/kubernetes/ipam.go
@@ -309,10 +309,10 @@ func newLeaderElector(clientset *kubernetes.Clientset, namespace string, podName
 	// Make the leader elector, ready to be used in the Workgroup.
 	// !bang
 	le, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
-		Lock:          rl,
-		LeaseDuration: time.Duration(leaseDuration) * time.Millisecond,
-		RenewDeadline: time.Duration(renewDeadline) * time.Millisecond,
-		RetryPeriod:   time.Duration(retryPeriod) * time.Millisecond,
+		Lock:            rl,
+		LeaseDuration:   time.Duration(leaseDuration) * time.Millisecond,
+		RenewDeadline:   time.Duration(renewDeadline) * time.Millisecond,
+		RetryPeriod:     time.Duration(retryPeriod) * time.Millisecond,
 		ReleaseOnCancel: true,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(_ context.Context) {
@@ -499,6 +499,11 @@ RETRYLOOP:
 			if rl.IsAllocated != true {
 				usereservelist = append(usereservelist, rl)
 			}
+		}
+
+		// Manual race condition testing
+		if ipamConf.SleepForRace {
+			time.Sleep(20 * time.Second)
 		}
 
 		err = pool.Update(requestCtx, usereservelist)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -52,6 +52,7 @@ type IPAMConfig struct {
 	LogFile             string            `json:"log_file"`
 	LogLevel            string            `json:"log_level"`
 	OverlappingRanges   bool              `json:"enable_overlapping_ranges,omitempty"`
+	SleepForRace        bool              `json:"sleep_for_race,omitempty"`
 	Gateway             net.IP
 	Kubernetes          KubernetesConfig `json:"kubernetes,omitempty"`
 	ConfigurationPath   string           `json:"configuration_path"`


### PR DESCRIPTION
Pods can be given IPAM field sleep_for_race, which if set to "true" will cause a pod to sleep for 20 seconds before updating IP pool. If another pod is spun up within those 20 seconds without sleep_for_race set to true, it should take the same IP address given to the first pod, and can serve as a test for whether race conditions are present.