### PR TITLE
Fix test to include error when IP pool total doesn't equal assigned WB pod IPs

### DIFF
--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -211,6 +211,11 @@ is_ippool_consistent() {
 
   echo "#### found '${#ippool_keys[@]}' IP pool ids in '$pool_name' and '${#pod_ips[@]}' pod IPs"
 
+  if [[ ${#ippool_keys[@]} -ne ${#pod_ips[@]} ]]; then
+    echo "#### number of IP pools IPs does not equal number of whereabouts assigned pods IPs"
+    exit_code=4
+  fi
+
   for ippool_key in ${ippool_keys[@]}; do
     resolved_ippool_ip="${ips[$ippool_key]}"
     found=false

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -68,7 +68,7 @@ wait_until_all_pods() {
   local pod_phases
   while [[ $timeout -gt 0 ]]; do
     all_running=true
-    pod_phases="$(kubectl get pods --namespace $namespace --output jsonpath="{range .items[*]}{.status.phase}{' '}{end}")"
+    pod_phases="$(kubectl get pods --namespace $namespace --selector $WB_LABEL_EQUAL --output jsonpath="{range .items[*]}{.status.phase}{' '}{end}")"
     for phase in $pod_phases; do
       if [[ $phase != "Running" ]] && [[ $phase != "Succeeded" ]]; then
         all_running=false
@@ -89,7 +89,7 @@ wait_until_all_pods_terminated() {
   local namespace="$1"
   local timeout=${TIMEOUT:-300}
   while [[ $timeout -gt 0 ]]; do
-    if ! kubectl get pods --namespace $namespace | grep Terminating >/dev/null; then
+    if ! kubectl get pods --namespace $namespace --selector $WB_LABEL_EQUAL | grep Terminating >/dev/null; then
       return 0
     fi
     sleep 1


### PR DESCRIPTION
The tests check if IP pool IPs are seen in assigned WB pod IPs.
The tests check if pod IPs are seen in IP pool
but there maybe duplicate IP(s) assigned that isn't accounted for so we check if the total IPs assigned is equal to the total seen in IP pool.

 