### PR TITLE
build, ip reconciler: have configurable logging

### DIFF
--- a/cmd/reconciler/ip.go
+++ b/cmd/reconciler/ip.go
@@ -12,12 +12,14 @@ import (
 
 func main() {
 	kubeConfigFile := flag.String("kubeconfig", "", "the path to the Kubernetes configuration file")
+	logLevel := flag.String("log-level", "error", "the logging level for the `ip-reconciler` app. Valid values are: \"debug\", \"verbose\", \"error\", and \"panic\".")
 	flag.Parse()
 
 	if *kubeConfigFile == "" {
 		_ = logging.Errorf("must specify the kubernetes config file, via the '-kubeconfig' flag")
 		os.Exit(kubeconfigNotFound)
 	}
+	logging.SetLogLevel(*logLevel)
 
 	ctx, cancel := context.WithTimeout(context.Background(), storage.RequestTimeout)
 	defer cancel()

--- a/doc/crds/ip-reconciler-job.yaml
+++ b/doc/crds/ip-reconciler-job.yaml
@@ -24,6 +24,7 @@ spec:
               command:
                 - /ip-reconciler
                 - -kubeconfig=/host/etc/cni/net.d/whereabouts.d/whereabouts.kubeconfig
+                - -log-level=verbose
               volumeMounts:
                 - name: cni-net-dir
                   mountPath: /host/etc/cni/net.d


### PR DESCRIPTION
The ip-reconciler tool currently feature the logging level
hard-coded to `debug`, which is too verbose.

This commit makes it configurable, defaulting it to error level.

Some example output:

```bash
$ bin/ip-reconciler -kubeconfig=$KUBECONFIG 
$ bin/ip-reconciler -kubeconfig=$KUBECONFIG -log-level=debug
2021-10-06T16:31:27+02:00 [debug] NewReconcileLooper - Kubernetes config file located at: <XYZ>
2021-10-06T16:31:27+02:00 [debug] successfully read the kubernetes configuration file located at: <XYZ>
2021-10-06T16:31:27+02:00 [debug] listing IP pools
2021-10-06T16:31:27+02:00 [debug] no IP addresses to cleanup
```

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>