### PR TITLE
ip-reconciler: remove kubeconfig from k8s client

### DIFF
--- a/cmd/reconciler/ip_test.go
+++ b/cmd/reconciler/ip_test.go
@@ -10,9 +10,9 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	multusv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/api/v1alpha1"
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/reconciler"
-	multusv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,7 +66,7 @@ var _ = Describe("Whereabouts IP reconciler", func() {
 				Context("reconciling the IPPool", func() {
 					BeforeEach(func() {
 						var err error
-						reconcileLooper, err = reconciler.NewReconcileLooper(kubeConfigPath, context.TODO())
+						reconcileLooper, err = reconciler.NewReconcileLooperWithKubeconfig(kubeConfigPath, context.TODO())
 						Expect(err).NotTo(HaveOccurred())
 					})
 
@@ -137,7 +137,7 @@ var _ = Describe("Whereabouts IP reconciler", func() {
 			Context("reconciling the IPPool", func() {
 				BeforeEach(func() {
 					var err error
-					reconcileLooper, err = reconciler.NewReconcileLooper(kubeConfigPath, context.TODO())
+					reconcileLooper, err = reconciler.NewReconcileLooperWithKubeconfig(kubeConfigPath, context.TODO())
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -242,7 +242,7 @@ var _ = Describe("Whereabouts IP reconciler", func() {
 
 		It("will delete an orphaned IP address", func() {
 			Expect(k8sClientSet.CoreV1().Pods(namespace).Delete(context.TODO(), pods[podIndexToRemove].Name, metav1.DeleteOptions{})).NotTo(HaveOccurred())
-			newReconciler, err := reconciler.NewReconcileLooper(kubeConfigPath, context.TODO())
+			newReconciler, err := reconciler.NewReconcileLooperWithKubeconfig(kubeConfigPath, context.TODO())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(newReconciler.ReconcileOverlappingIPAddresses()).To(Succeed())
 

--- a/doc/crds/ip-reconciler-job.yaml
+++ b/doc/crds/ip-reconciler-job.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: ip-reconciler
+  namespace: kube-system
   labels:
     tier: node
     app: whereabouts
@@ -12,6 +13,7 @@ spec:
       template:
         spec:
           priorityClassName: "system-node-critical"
+          serviceAccountName: whereabouts
           containers:
             - name: whereabouts
               image: ghcr.io/k8snetworkplumbingwg/whereabouts:latest-amd64
@@ -21,7 +23,6 @@ spec:
                   memory: "50Mi"
               command:
                 - /ip-reconciler
-                - -kubeconfig=/host/etc/cni/net.d/whereabouts.d/whereabouts.kubeconfig
                 - -log-level=verbose
               volumeMounts:
                 - name: cni-net-dir

--- a/hack/install-kubebuilder-tools.sh
+++ b/hack/install-kubebuilder-tools.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
+OCI_BIN=${OCI_BIN:-docker}
 
 # install controller-gen
 go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1
 
 # install kubebuilder tools to bin/
 mkdir -p bin
-containerID=$(docker create gcr.io/kubebuilder/thirdparty-linux:1.16.4)
-docker cp ${containerID}:/kubebuilder_linux_amd64.tar.gz ./kubebuilder_linux_amd64.tar.gz
-docker rm ${containerID}
+containerID=$("$OCI_BIN" create gcr.io/kubebuilder/thirdparty-linux:1.16.4)
+"$OCI_BIN" cp ${containerID}:/kubebuilder_linux_amd64.tar.gz ./kubebuilder_linux_amd64.tar.gz
+"$OCI_BIN" rm ${containerID}
 tar -xzvf kubebuilder_linux_amd64.tar.gz
 rm kubebuilder_linux_amd64.tar.gz
 mv kubebuilder/bin/* bin/
 rm -rf kubebuilder/
 chmod +x bin/
+

--- a/pkg/reconciler/iploop.go
+++ b/pkg/reconciler/iploop.go
@@ -28,14 +28,25 @@ type OrphanedIPReservations struct {
 	Allocations []types.IPReservation
 }
 
-func NewReconcileLooper(kubeConfigPath string, ctx context.Context) (*ReconcileLooper, error) {
-	logging.Debugf("NewReconcileLooper - Kubernetes config file located at: %s", kubeConfigPath)
-	k8sClient, err := kubernetes.NewClient(kubeConfigPath)
+func NewReconcileLooperWithKubeconfig(kubeconfigPath string, ctx context.Context) (*ReconcileLooper, error) {
+	logging.Debugf("NewReconcileLooper - Kubernetes config file located at: %s", kubeconfigPath)
+	k8sClient, err := kubernetes.NewClientViaKubeconfig(kubeconfigPath)
 	if err != nil {
 		return nil, logging.Errorf("failed to instantiate the Kubernetes client: %+v", err)
 	}
-	logging.Debugf("successfully read the kubernetes configuration file located at: %s", kubeConfigPath)
+	return newReconcileLooper(k8sClient, ctx)
+}
 
+func NewReconcileLooper(ctx context.Context) (*ReconcileLooper, error) {
+	logging.Debugf("NewReconcileLooper - inferred connection data")
+	k8sClient, err := kubernetes.NewClient()
+	if err != nil {
+		return nil, logging.Errorf("failed to instantiate the Kubernetes client: %+v", err)
+	}
+	return newReconcileLooper(k8sClient, ctx)
+}
+
+func newReconcileLooper(k8sClient *kubernetes.Client, ctx context.Context) (*ReconcileLooper, error) {
 	pods, err := k8sClient.ListPods()
 	if err != nil {
 		return nil, err

--- a/pkg/reconciler/iploop.go
+++ b/pkg/reconciler/iploop.go
@@ -179,7 +179,7 @@ func (rl ReconcileLooper) ReconcileOverlappingIPAddresses() error {
 			failedReconciledClusterWideIPs = append(failedReconciledClusterWideIPs, overlappingIPStruct.GetName())
 			continue
 		}
-		logging.Debugf("removed stale overlappingIP allocation [%s]", overlappingIPStruct.GetName())
+		logging.Verbosef("removed stale overlappingIP allocation [%s]", overlappingIPStruct.GetName())
 	}
 
 	if len(failedReconciledClusterWideIPs) != 0 {

--- a/pkg/storage/kubernetes/client.go
+++ b/pkg/storage/kubernetes/client.go
@@ -10,6 +10,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -22,17 +23,34 @@ type Client struct {
 	retries   int
 }
 
-func NewClient(kubeconfigPath string) (*Client, error) {
+func NewClient() (*Client, error) {
+	scheme := runtime.NewScheme()
+	_ = whereaboutsv1alpha1.AddToScheme(scheme)
+
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return newClient(config, scheme)
+}
+
+func NewClientViaKubeconfig(kubeconfigPath string) (*Client, error) {
 	scheme := runtime.NewScheme()
 	_ = whereaboutsv1alpha1.AddToScheme(scheme)
 
 	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfigPath},
 		&clientcmd.ConfigOverrides{}).ClientConfig()
+
 	if err != nil {
 		return nil, err
 	}
 
+	return newClient(config, scheme)
+}
+
+func newClient(config *rest.Config, schema *runtime.Scheme) (*Client, error) {
 	clientSet, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, err
@@ -42,7 +60,7 @@ func NewClient(kubeconfigPath string) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	c, err := client.New(config, client.Options{Scheme: scheme, Mapper: mapper})
+	c, err := client.New(config, client.Options{Scheme: schema, Mapper: mapper})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/kubernetes/ipam.go
+++ b/pkg/storage/kubernetes/ipam.go
@@ -38,7 +38,7 @@ func NewKubernetesIPAM(containerID string, ipamConf whereaboutstypes.IPAMConfig)
 		return nil, fmt.Errorf("k8s config: namespace not present in context")
 	}
 
-	kubernetesClient, err := NewClient(ipamConf.Kubernetes.KubeConfigPath)
+	kubernetesClient, err := NewClientViaKubeconfig(ipamConf.Kubernetes.KubeConfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed instantiating kubernetes client: %v", err)
 	}


### PR DESCRIPTION
With this change the reconciler can run in two different ways:
- when ran in a k8s pod, it does not require to be told how to
  connect to the cluster.
- when ran as a binary, it does require to know how to connect to
  the cluster, via the -kubeconfig config option.
    
The reconciler cron spec is updated to use the correct service
account name, and also is updated to run in the `kube-system`
namespace.

The main whereabouts IPAM plugin - while it could - is kept as
it was, and thus relies on the kubeconfig file path.

Changing that should happen in a follow up PR.
