### PR TITLE
feat: Static ip allocations only

### DIFF
--- a/pkg/allocate/allocate_test.go
+++ b/pkg/allocate/allocate_test.go
@@ -2,11 +2,12 @@ package allocate
 
 import (
 	"fmt"
-	"github.com/k8snetworkplumbingwg/whereabouts/pkg/types"
 	"math"
 	"math/big"
 	"net"
 	"testing"
+
+	"github.com/k8snetworkplumbingwg/whereabouts/pkg/types"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -260,8 +261,27 @@ var _ = Describe("Allocation operations", func() {
 		var ipres []types.IPReservation
 		var exrange []string
 		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
-		Expect(fmt.Sprint(newip)).To(Equal("192.168.1.1"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fmt.Sprint(newip[0])).To(Equal("192.168.1.1"))
+	})
 
+	It("can allocate static IPv4 address", func() {
+		_, ipnet, err := net.ParseCIDR("192.168.1.1/24")
+		Expect(err).NotTo(HaveOccurred())
+
+		ip, statIP, err := net.ParseCIDR("192.168.1.20/24")
+		Expect(err).NotTo(HaveOccurred())
+
+		var ipres []types.IPReservation
+		ipamConf := types.IPAMConfig{
+			Addresses: []types.Address{{Address: net.IPNet{
+				IP:   ip,
+				Mask: statIP.Mask,
+			},
+			},
+			}}
+		newip, _, err := assignStaticAllocation(*ipnet, ipamConf, ipres, "0xdeadbeef", "")
+		Expect(fmt.Sprint(newip[0])).To(Equal("192.168.1.20"))
 	})
 
 	It("can IterateForAssignment on an IPv6 address when the first hextet has NO leading zeroes", func() {
@@ -275,7 +295,7 @@ var _ = Describe("Allocation operations", func() {
 		var ipres []types.IPReservation
 		var exrange []string
 		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
-		Expect(fmt.Sprint(newip)).To(Equal("caa5::1"))
+		Expect(fmt.Sprint(newip[0])).To(Equal("caa5::1"))
 
 	})
 
@@ -290,7 +310,7 @@ var _ = Describe("Allocation operations", func() {
 		var ipres []types.IPReservation
 		var exrange []string
 		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
-		Expect(fmt.Sprint(newip)).To(Equal("::1"))
+		Expect(fmt.Sprint(newip[0])).To(Equal("::1"))
 
 	})
 
@@ -307,7 +327,7 @@ var _ = Describe("Allocation operations", func() {
 		var ipres []types.IPReservation
 		var exrange []string
 		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
-		Expect(fmt.Sprint(newip)).To(Equal("fd::1"))
+		Expect(fmt.Sprint(newip[0])).To(Equal("fd::1"))
 
 	})
 
@@ -322,7 +342,7 @@ var _ = Describe("Allocation operations", func() {
 		var ipres []types.IPReservation
 		var exrange []string
 		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
-		Expect(fmt.Sprint(newip)).To(Equal("100::2:1"))
+		Expect(fmt.Sprint(newip[0])).To(Equal("100::2:1"))
 
 	})
 

--- a/pkg/storage/etcd.go
+++ b/pkg/storage/etcd.go
@@ -93,7 +93,7 @@ func (i *EtcdOverlappingRangeStore) IsAllocatedInOverlappingRange(ctx context.Co
 }
 
 // UpdateOverlappingRangeAllocation updates our clusterwide allocation for overlapping ranges.
-func (i *EtcdOverlappingRangeStore) UpdateOverlappingRangeAllocation(ctx context.Context, mode int, ip net.IP, containerID string, podRef string) error {
+func (i *EtcdOverlappingRangeStore) UpdateOverlappingRangeAllocation(ctx context.Context, mode int, ip []net.IP, containerID string, podRef string) error {
 	logging.Debugf("ETCD UpdateOverlappingRangeWide is NOT IMPLEMENTED!!!! TODO")
 	return nil
 }
@@ -163,11 +163,11 @@ func (p *ETCDIPPool) Update(ctx context.Context, reservations []types.IPReservat
 }
 
 // IPManagement manages ip allocation and deallocation from a storage perspective
-func IPManagementEtcd(ctx context.Context, mode int, ipamConf types.IPAMConfig, containerID string, podRef string) (net.IPNet, error) {
+func IPManagementEtcd(ctx context.Context, mode int, ipamConf types.IPAMConfig, containerID string, podRef string) ([]net.IPNet, error) {
 
 	logging.Debugf("IPManagement -- mode: %v / host: %v / containerID: %v / podRef: %v", mode, ipamConf.EtcdHost, containerID, podRef)
 
-	var newip net.IPNet
+	var newip []net.IPNet
 	// Skip invalid modes
 	switch mode {
 	case types.Allocate, types.Deallocate:
@@ -179,7 +179,7 @@ func IPManagementEtcd(ctx context.Context, mode int, ipamConf types.IPAMConfig, 
 	var pool IPPool
 	var err error
 	if ipamConf.Datastore != types.DatastoreETCD {
-		return net.IPNet{}, logging.Errorf("wrong 'datastore' value in IPAM config: %s", ipamConf.Datastore)
+		return []net.IPNet{}, logging.Errorf("wrong 'datastore' value in IPAM config: %s", ipamConf.Datastore)
 	}
 	ipam, err = NewETCDIPAM(ctx, ipamConf)
 	if err != nil {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -33,7 +33,7 @@ type Store interface {
 // OverlappingRangeStore is an interface for wrapping overlappingrange storage options
 type OverlappingRangeStore interface {
 	IsAllocatedInOverlappingRange(ctx context.Context, ip net.IP) (bool, error)
-	UpdateOverlappingRangeAllocation(ctx context.Context, mode int, ip net.IP, containerID string, podRef string) error
+	UpdateOverlappingRangeAllocation(ctx context.Context, mode int, ip []net.IP, containerID string, podRef string) error
 }
 
 type Temporary interface {


### PR DESCRIPTION
When user wants only static IP address whereabouts should not reserve double addresses but put the static allocation into the list of reserved IPs.

Fixes #111 
