### PR TITLE
build: synch the golang builders w/ the go version on go.mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13
+FROM golang:1.15
 ADD . /usr/src/whereabouts
 RUN mkdir -p $GOPATH/src/github.com/k8snetworkplumbingwg/whereabouts
 WORKDIR $GOPATH/src/github.com/k8snetworkplumbingwg/whereabouts

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM golang:1.13
+FROM golang:1.15
 ADD . /usr/src/whereabouts
 
 ENV GOARCH "arm64"


### PR DESCRIPTION
go.mod has 1.15 while the builders have 1.13.

Oddly enough, for whatever reason, the openshift img builder already runs 1.15. 
