### PR TITLE
Fix context reconciler

### DIFF
--- a/cmd/reconciler/ip.go
+++ b/cmd/reconciler/ip.go
@@ -25,14 +25,14 @@ func main() {
 	if kubeConfigFile == nil {
 		ipReconcileLoop, err = reconciler.NewReconcileLooper(ctx)
 	} else {
-		ipReconcileLoop, err = reconciler.NewReconcileLooperWithKubeconfig(*kubeConfigFile, ctx)
+		ipReconcileLoop, err = reconciler.NewReconcileLooperWithKubeconfig(ctx, *kubeConfigFile)
 	}
 	if err != nil {
 		_ = logging.Errorf("failed to create the reconcile looper: %v", err)
 		os.Exit(couldNotStartOrphanedIPMonitor)
 	}
 
-	cleanedUpIps, err := ipReconcileLoop.ReconcileIPPools()
+	cleanedUpIps, err := ipReconcileLoop.ReconcileIPPools(ctx)
 	if err != nil {
 		_ = logging.Errorf("failed to clean up IP for allocations: %v", err)
 		os.Exit(failedToReconcileIPPools)
@@ -43,7 +43,7 @@ func main() {
 		logging.Debugf("no IP addresses to cleanup")
 	}
 
-	if err := ipReconcileLoop.ReconcileOverlappingIPAddresses(); err != nil {
+	if err := ipReconcileLoop.ReconcileOverlappingIPAddresses(ctx); err != nil {
 		os.Exit(failedToReconcileClusterWideIPs)
 	}
 }

--- a/cmd/reconciler/ip.go
+++ b/cmd/reconciler/ip.go
@@ -3,36 +3,35 @@ package main
 import (
 	"context"
 	"flag"
-	"github.com/k8snetworkplumbingwg/whereabouts/pkg/storage"
 	"os"
 
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/logging"
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/reconciler"
 )
 
+const defaultReconcilerTimeout = 30
+
 func main() {
 	kubeConfigFile := flag.String("kubeconfig", "", "the path to the Kubernetes configuration file")
 	logLevel := flag.String("log-level", "error", "the logging level for the `ip-reconciler` app. Valid values are: \"debug\", \"verbose\", \"error\", and \"panic\".")
+	reconcilerTimeout := flag.Int("timeout", defaultReconcilerTimeout, "the value for a request timeout in seconds.")
 	flag.Parse()
 
 	logging.SetLogLevel(*logLevel)
 
-	ctx, cancel := context.WithTimeout(context.Background(), storage.RequestTimeout)
-	defer cancel()
-
 	var err error
 	var ipReconcileLoop *reconciler.ReconcileLooper
 	if kubeConfigFile == nil {
-		ipReconcileLoop, err = reconciler.NewReconcileLooper(ctx)
+		ipReconcileLoop, err = reconciler.NewReconcileLooper(context.Background(), *reconcilerTimeout)
 	} else {
-		ipReconcileLoop, err = reconciler.NewReconcileLooperWithKubeconfig(ctx, *kubeConfigFile)
+		ipReconcileLoop, err = reconciler.NewReconcileLooperWithKubeconfig(context.Background(), *kubeConfigFile, *reconcilerTimeout)
 	}
 	if err != nil {
 		_ = logging.Errorf("failed to create the reconcile looper: %v", err)
 		os.Exit(couldNotStartOrphanedIPMonitor)
 	}
 
-	cleanedUpIps, err := ipReconcileLoop.ReconcileIPPools(ctx)
+	cleanedUpIps, err := ipReconcileLoop.ReconcileIPPools(context.Background())
 	if err != nil {
 		_ = logging.Errorf("failed to clean up IP for allocations: %v", err)
 		os.Exit(failedToReconcileIPPools)
@@ -43,7 +42,7 @@ func main() {
 		logging.Debugf("no IP addresses to cleanup")
 	}
 
-	if err := ipReconcileLoop.ReconcileOverlappingIPAddresses(ctx); err != nil {
+	if err := ipReconcileLoop.ReconcileOverlappingIPAddresses(context.Background()); err != nil {
 		os.Exit(failedToReconcileClusterWideIPs)
 	}
 }

--- a/cmd/reconciler/ip_test.go
+++ b/cmd/reconciler/ip_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Whereabouts IP reconciler", func() {
 				Context("reconciling the IPPool", func() {
 					BeforeEach(func() {
 						var err error
-						reconcileLooper, err = reconciler.NewReconcileLooperWithKubeconfig(kubeConfigPath, context.TODO())
+						reconcileLooper, err = reconciler.NewReconcileLooperWithKubeconfig(context.TODO(), kubeConfigPath)
 						Expect(err).NotTo(HaveOccurred())
 					})
 
@@ -137,7 +137,7 @@ var _ = Describe("Whereabouts IP reconciler", func() {
 			Context("reconciling the IPPool", func() {
 				BeforeEach(func() {
 					var err error
-					reconcileLooper, err = reconciler.NewReconcileLooperWithKubeconfig(kubeConfigPath, context.TODO())
+					reconcileLooper, err = reconciler.NewReconcileLooperWithKubeconfig(context.TODO(), kubeConfigPath)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -242,7 +242,7 @@ var _ = Describe("Whereabouts IP reconciler", func() {
 
 		It("will delete an orphaned IP address", func() {
 			Expect(k8sClientSet.CoreV1().Pods(namespace).Delete(context.TODO(), pods[podIndexToRemove].Name, metav1.DeleteOptions{})).NotTo(HaveOccurred())
-			newReconciler, err := reconciler.NewReconcileLooperWithKubeconfig(kubeConfigPath, context.TODO())
+			newReconciler, err := reconciler.NewReconcileLooperWithKubeconfig(context.TODO(), kubeConfigPath)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(newReconciler.ReconcileOverlappingIPAddresses()).To(Succeed())
 
@@ -270,7 +270,7 @@ var _ = Describe("Whereabouts IP reconciler", func() {
 			pool = generateIPPoolSpec(ipRange, namespace, poolName, pod.Name)
 			Expect(k8sClient.Create(context.Background(), pool)).NotTo(HaveOccurred())
 
-			reconcileLooper, err = reconciler.NewReconcileLooperWithKubeconfig(kubeConfigPath, context.TODO())
+			reconcileLooper, err = reconciler.NewReconcileLooperWithKubeconfig(context.TODO(), kubeConfigPath)
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/cmd/reconciler/ip_test.go
+++ b/cmd/reconciler/ip_test.go
@@ -26,6 +26,7 @@ var _ = Describe("Whereabouts IP reconciler", func() {
 		namespace      = "default"
 		networkName    = "net1"
 		podName        = "pod1"
+		timeout        = 10
 	)
 
 	var (
@@ -66,16 +67,16 @@ var _ = Describe("Whereabouts IP reconciler", func() {
 				Context("reconciling the IPPool", func() {
 					BeforeEach(func() {
 						var err error
-						reconcileLooper, err = reconciler.NewReconcileLooperWithKubeconfig(context.TODO(), kubeConfigPath)
+						reconcileLooper, err = reconciler.NewReconcileLooperWithKubeconfig(context.TODO(), kubeConfigPath, timeout)
 						Expect(err).NotTo(HaveOccurred())
 					})
 
 					It("should report the deleted IP reservation", func() {
-						Expect(reconcileLooper.ReconcileIPPools()).To(Equal([]net.IP{net.ParseIP("10.10.10.1")}))
+						Expect(reconcileLooper.ReconcileIPPools(context.TODO())).To(Equal([]net.IP{net.ParseIP("10.10.10.1")}))
 					})
 
 					It("the pool's orphaned IP should be deleted after the reconcile loop", func() {
-						_, err := reconcileLooper.ReconcileIPPools()
+						_, err := reconcileLooper.ReconcileIPPools(context.TODO())
 						Expect(err).NotTo(HaveOccurred())
 						var poolAfterCleanup v1alpha1.IPPool
 						poolKey := k8stypes.NamespacedName{Namespace: namespace, Name: pool.Name}
@@ -137,18 +138,18 @@ var _ = Describe("Whereabouts IP reconciler", func() {
 			Context("reconciling the IPPool", func() {
 				BeforeEach(func() {
 					var err error
-					reconcileLooper, err = reconciler.NewReconcileLooperWithKubeconfig(context.TODO(), kubeConfigPath)
+					reconcileLooper, err = reconciler.NewReconcileLooperWithKubeconfig(context.TODO(), kubeConfigPath, timeout)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
 				It("should report the dead pod's IP address as deleted", func() {
-					deletedIPAddrs, err := reconcileLooper.ReconcileIPPools()
+					deletedIPAddrs, err := reconcileLooper.ReconcileIPPools(context.TODO())
 					Expect(err).NotTo(HaveOccurred())
 					Expect(deletedIPAddrs).To(Equal([]net.IP{net.ParseIP("10.10.10.1")}))
 				})
 
 				It("the IPPool should have only the IP reservation of the live pod", func() {
-					deletedIPAddrs, err := reconcileLooper.ReconcileIPPools()
+					deletedIPAddrs, err := reconcileLooper.ReconcileIPPools(context.TODO())
 					Expect(err).NotTo(HaveOccurred())
 					Expect(deletedIPAddrs).NotTo(BeEmpty())
 
@@ -242,9 +243,9 @@ var _ = Describe("Whereabouts IP reconciler", func() {
 
 		It("will delete an orphaned IP address", func() {
 			Expect(k8sClientSet.CoreV1().Pods(namespace).Delete(context.TODO(), pods[podIndexToRemove].Name, metav1.DeleteOptions{})).NotTo(HaveOccurred())
-			newReconciler, err := reconciler.NewReconcileLooperWithKubeconfig(context.TODO(), kubeConfigPath)
+			newReconciler, err := reconciler.NewReconcileLooperWithKubeconfig(context.TODO(), kubeConfigPath, timeout)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(newReconciler.ReconcileOverlappingIPAddresses()).To(Succeed())
+			Expect(newReconciler.ReconcileOverlappingIPAddresses(context.TODO())).To(Succeed())
 
 			expectedClusterWideIPs := 2
 			var clusterWideIPAllocations v1alpha1.OverlappingRangeIPReservationList
@@ -270,7 +271,7 @@ var _ = Describe("Whereabouts IP reconciler", func() {
 			pool = generateIPPoolSpec(ipRange, namespace, poolName, pod.Name)
 			Expect(k8sClient.Create(context.Background(), pool)).NotTo(HaveOccurred())
 
-			reconcileLooper, err = reconciler.NewReconcileLooperWithKubeconfig(context.TODO(), kubeConfigPath)
+			reconcileLooper, err = reconciler.NewReconcileLooperWithKubeconfig(context.TODO(), kubeConfigPath, timeout)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -280,7 +281,7 @@ var _ = Describe("Whereabouts IP reconciler", func() {
 		})
 
 		It("cannot be reconciled", func() {
-			Expect(reconcileLooper.ReconcileIPPools()).To(BeEmpty())
+			Expect(reconcileLooper.ReconcileIPPools(context.TODO())).To(BeEmpty())
 		})
 	})
 })

--- a/pkg/reconciler/iploop_test.go
+++ b/pkg/reconciler/iploop_test.go
@@ -37,7 +37,6 @@ var _ = Describe("IPReconciler", func() {
 
 	newIPReconciler := func(orphanedIPs ...OrphanedIPReservations) *ReconcileLooper {
 		reconciler := &ReconcileLooper{
-			ctx:         context.TODO(),
 			orphanedIPs: orphanedIPs,
 		}
 
@@ -50,7 +49,7 @@ var _ = Describe("IPReconciler", func() {
 		})
 
 		It("does not delete anything", func() {
-			reconciledIPs, err := ipReconciler.ReconcileIPPools()
+			reconciledIPs, err := ipReconciler.ReconcileIPPools(context.TODO())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(reconciledIPs).To(BeEmpty())
 		})
@@ -78,7 +77,7 @@ var _ = Describe("IPReconciler", func() {
 		})
 
 		It("does delete the orphaned IP address", func() {
-			reconciledIPs, err := ipReconciler.ReconcileIPPools()
+			reconciledIPs, err := ipReconciler.ReconcileIPPools(context.TODO())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(reconciledIPs).To(Equal([]net.IP{net.ParseIP(firstIPInRange)}))
 		})
@@ -98,7 +97,7 @@ var _ = Describe("IPReconciler", func() {
 			})
 
 			It("does delete *only the orphaned* the IP address", func() {
-				reconciledIPs, err := ipReconciler.ReconcileIPPools()
+				reconciledIPs, err := ipReconciler.ReconcileIPPools(context.TODO())
 				Expect(err).NotTo(HaveOccurred())
 				Expect(reconciledIPs).To(ConsistOf([]net.IP{net.ParseIP("192.168.14.2")}))
 			})
@@ -122,7 +121,7 @@ var _ = Describe("IPReconciler", func() {
 			})
 
 			It("errors when attempting to clean up the IP address", func() {
-				reconciledIPs, err := ipReconciler.ReconcileIPPools()
+				reconciledIPs, err := ipReconciler.ReconcileIPPools(context.TODO())
 				Expect(err).To(MatchError(fmt.Sprintf("Did not find reserved IP for container %s", reservationPodRef)))
 				Expect(reconciledIPs).To(BeEmpty())
 			})

--- a/pkg/storage/kubernetes/client.go
+++ b/pkg/storage/kubernetes/client.go
@@ -80,7 +80,9 @@ func (i *Client) ListIPPools(ctx context.Context) ([]storage.IPPool, error) {
 	logging.Debugf("listing IP pools")
 	ipPoolList := &whereaboutsv1alpha1.IPPoolList{}
 
-	if err := i.client.List(ctx, ipPoolList, &client.ListOptions{}); err != nil {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, storage.RequestTimeout)
+	defer cancel()
+	if err := i.client.List(ctxWithTimeout, ipPoolList, &client.ListOptions{}); err != nil {
 		return nil, err
 	}
 
@@ -97,8 +99,11 @@ func (i *Client) ListIPPools(ctx context.Context) ([]storage.IPPool, error) {
 	return whereaboutsApiIPPoolList, nil
 }
 
-func (i *Client) ListPods() ([]v1.Pod, error) {
-	podList, err := i.clientSet.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+func (i *Client) ListPods(ctx context.Context) ([]v1.Pod, error) {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, storage.RequestTimeout)
+	defer cancel()
+
+	podList, err := i.clientSet.CoreV1().Pods(metav1.NamespaceAll).List(ctxWithTimeout, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Follow the golang context convention [0], which says:
"""
Do not store Contexts inside a struct type; instead, pass a Context explicitly
to each function that needs it. The Context should be the first parameter,
typically named ctx:
...
"""

[0] - https://pkg.go.dev/context

Furthermore, this PR also changes the reconciler behavior to use a different
context per each list operation. All contexts are cancelable, and have a timeout.
    
The timeout can be specified via the reconciler command line arguments,
and defaults to 30 seconds.

Fixes: #172