### PR TITLE
ip reconciler: auto clean failed jobs

### DIFF
--- a/doc/crds/ip-reconciler-job.yaml
+++ b/doc/crds/ip-reconciler-job.yaml
@@ -13,6 +13,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 0
+      ttlSecondsAfterFinished: 300
       template:
         metadata:
           labels:


### PR DESCRIPTION
This commit makes use of the `ttlSecondsAfterFinished` to auto clean the
failed jobs.

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>