### PR TITLE
Remove golint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,8 @@ jobs:
     - name: Run go vet
       run: go vet ./...
 
-    - name: Install golint
-      run: GO111MODULE=off GOBIN=$(pwd)/bin go get golang.org/x/lint/golint
+    - name: Install static check
+      run: go install honnef.co/go/tools/cmd/staticcheck@latest
 
     - name: Test
       run: sudo PATH=${PATH}:./bin ./hack/test-go.sh

--- a/cmd/whereabouts.go
+++ b/cmd/whereabouts.go
@@ -61,7 +61,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 	if err != nil {
 		logging.Errorf("Error at storage engine: %s", err)
-		return fmt.Errorf("Error at storage engine: %w", err)
+		return fmt.Errorf("error at storage engine: %w", err)
 	}
 
 	// Determine if v4 or v6.

--- a/cmd/whereabouts_test.go
+++ b/cmd/whereabouts_test.go
@@ -610,7 +610,7 @@ var _ = Describe("Whereabouts operations", func() {
 
 		// assigning more IPs should result in error due to the defined range_start - range_end
 		args := &skel.CmdArgs{
-			ContainerID: fmt.Sprintf("dummy-failure"),
+			ContainerID: "dummy-failure",
 			Netns:       nspath,
 			IfName:      ifname,
 			StdinData:   []byte(conf),

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -2,7 +2,11 @@
 # single test: go test -v ./pkg/storage/
 # without cache: go test -count=1 -v ./pkg/storage/
 set -e -x
-echo "Linting go code..."
-golint ./cmd ./pkg
+echo "Running go vet ..."
+go vet ./cmd/... ./pkg/...
+
+echo "Running golang staticcheck ..."
+staticcheck ./...
+
 echo "Running go tests..."
 KUBEBUILDER_ASSETS="$(pwd)/bin" go test -v -covermode=count -coverprofile=coverage.out ./...

--- a/pkg/allocate/allocate.go
+++ b/pkg/allocate/allocate.go
@@ -56,7 +56,7 @@ func IterateForDeallocation(
 	foundidx := matchingFunction(reservelist, containerID)
 	// Check if it's a valid index
 	if foundidx < 0 {
-		return reservelist, nil, fmt.Errorf("Did not find reserved IP for container %v", containerID)
+		return reservelist, nil, fmt.Errorf("did not find reserved IP for container %v", containerID)
 	}
 
 	returnip := reservelist[foundidx].IP
@@ -91,8 +91,7 @@ func byteSliceAdd(ar1, ar2 []byte) ([]byte, error) {
 
 	sumByte := make([]byte, 16)
 	for n := range ar1 {
-		var sum uint
-		sum = uint(ar1[15-n]) + uint(ar2[15-n]) + carry
+		sum := uint(ar1[15-n]) + uint(ar2[15-n]) + carry
 		carry = 0
 		if sum > 255 {
 			carry = 1
@@ -263,7 +262,7 @@ func GetIPRange(ip net.IP, ipnet net.IPNet) (net.IP, net.IP, error) {
 
 	// Error when the mask isn't large enough.
 	if masklen < 2 {
-		return nil, nil, fmt.Errorf("Net mask is too short, must be 2 or more: %v", masklen)
+		return nil, nil, fmt.Errorf("net mask is too short, must be 2 or more: %v", masklen)
 	}
 
 	// get network part

--- a/pkg/allocate/allocate_test.go
+++ b/pkg/allocate/allocate_test.go
@@ -166,8 +166,8 @@ var _ = Describe("Allocation utility functions", func() {
 var _ = Describe("Allocation operations", func() {
 	It("creates an IPv4 range properly for 30 bits network address", func() {
 
-		ip, ipnet, err := net.ParseCIDR("192.168.21.100/30")
-		ip, _ = AddressRange(ipnet)
+		_, ipnet, err := net.ParseCIDR("192.168.21.100/30")
+		ip, _ := AddressRange(ipnet)
 		Expect(err).NotTo(HaveOccurred())
 
 		firstip, lastip, err := GetIPRange(net.ParseIP(ip.String()), *ipnet)
@@ -178,8 +178,8 @@ var _ = Describe("Allocation operations", func() {
 	})
 	It("creates an IPv4 range properly for 24 bits network address with different range start", func() {
 
-		ip, ipnet, err := net.ParseCIDR("192.168.2.200/24")
-		ip = net.ParseIP("192.168.2.23") // range start
+		_, ipnet, err := net.ParseCIDR("192.168.2.200/24")
+		ip := net.ParseIP("192.168.2.23") // range start
 
 		Expect(err).NotTo(HaveOccurred())
 
@@ -192,8 +192,8 @@ var _ = Describe("Allocation operations", func() {
 	})
 	It("creates an IPv4 range properly for 27 bits network address", func() {
 
-		ip, ipnet, err := net.ParseCIDR("192.168.2.200/27")
-		ip, _ = AddressRange(ipnet)
+		_, ipnet, err := net.ParseCIDR("192.168.2.200/27")
+		ip, _ := AddressRange(ipnet)
 
 		Expect(err).NotTo(HaveOccurred())
 
@@ -205,8 +205,8 @@ var _ = Describe("Allocation operations", func() {
 	})
 	It("creates an IPv4 range properly for 24 bits network address", func() {
 
-		ip, ipnet, err := net.ParseCIDR("192.168.2.200/24")
-		ip, _ = AddressRange(ipnet)
+		_, ipnet, err := net.ParseCIDR("192.168.2.200/24")
+		ip, _ := AddressRange(ipnet)
 
 		Expect(err).NotTo(HaveOccurred())
 
@@ -221,8 +221,8 @@ var _ = Describe("Allocation operations", func() {
 	// Handy IPv6 CIDR calculator: https://www.ultratools.com/tools/ipv6CIDRToRangeResult?ipAddress=2001%3A%3A0%2F28
 	It("creates an IPv6 range properly for 116 bits network address", func() {
 
-		ip, ipnet, err := net.ParseCIDR("2001::0/116")
-		ip, _ = AddressRange(ipnet)
+		_, ipnet, err := net.ParseCIDR("2001::0/116")
+		ip, _ := AddressRange(ipnet)
 
 		Expect(err).NotTo(HaveOccurred())
 
@@ -236,8 +236,8 @@ var _ = Describe("Allocation operations", func() {
 
 	It("creates an IPv6 range when the first hextet has leading zeroes", func() {
 
-		ip, ipnet, err := net.ParseCIDR("fd:db8:abcd:0012::0/96")
-		ip, _ = AddressRange(ipnet)
+		_, ipnet, err := net.ParseCIDR("fd:db8:abcd:0012::0/96")
+		ip, _ := AddressRange(ipnet)
 
 		Expect(err).NotTo(HaveOccurred())
 
@@ -260,6 +260,7 @@ var _ = Describe("Allocation operations", func() {
 		var ipres []types.IPReservation
 		var exrange []string
 		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(newip)).To(Equal("192.168.1.1"))
 
 	})
@@ -275,6 +276,7 @@ var _ = Describe("Allocation operations", func() {
 		var ipres []types.IPReservation
 		var exrange []string
 		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(newip)).To(Equal("caa5::1"))
 
 	})
@@ -290,6 +292,7 @@ var _ = Describe("Allocation operations", func() {
 		var ipres []types.IPReservation
 		var exrange []string
 		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(newip)).To(Equal("::1"))
 
 	})
@@ -307,6 +310,7 @@ var _ = Describe("Allocation operations", func() {
 		var ipres []types.IPReservation
 		var exrange []string
 		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(newip)).To(Equal("fd::1"))
 
 	})
@@ -322,14 +326,14 @@ var _ = Describe("Allocation operations", func() {
 		var ipres []types.IPReservation
 		var exrange []string
 		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(newip)).To(Equal("100::2:1"))
-
 	})
 
 	It("creates an IPv6 range properly for 96 bits network address", func() {
 
-		ip, ipnet, err := net.ParseCIDR("2001:db8:abcd:0012::0/96")
-		ip, _ = AddressRange(ipnet)
+		_, ipnet, err := net.ParseCIDR("2001:db8:abcd:0012::0/96")
+		ip, _ := AddressRange(ipnet)
 
 		Expect(err).NotTo(HaveOccurred())
 
@@ -342,8 +346,8 @@ var _ = Describe("Allocation operations", func() {
 	})
 	It("creates an IPv6 range properly for 64 bits network address", func() {
 
-		ip, ipnet, err := net.ParseCIDR("2001:db8:abcd:0012::0/64")
-		ip, _ = AddressRange(ipnet)
+		_, ipnet, err := net.ParseCIDR("2001:db8:abcd:0012::0/64")
+		ip, _ := AddressRange(ipnet)
 
 		Expect(err).NotTo(HaveOccurred())
 
@@ -356,8 +360,8 @@ var _ = Describe("Allocation operations", func() {
 	})
 	It("do not fail when the mask meets minimum required", func() {
 
-		badip, badipnet, err := net.ParseCIDR("192.168.21.100/30")
-		badip, _ = AddressRange(badipnet)
+		_, badipnet, err := net.ParseCIDR("192.168.21.100/30")
+		badip, _ := AddressRange(badipnet)
 		Expect(err).NotTo(HaveOccurred())
 
 		_, _, err = GetIPRange(badip, *badipnet)
@@ -366,13 +370,13 @@ var _ = Describe("Allocation operations", func() {
 	})
 	It("fails when the mask is too short", func() {
 
-		badip, badipnet, err := net.ParseCIDR("192.168.21.100/31")
-		badip, _ = AddressRange(badipnet)
+		_, badipnet, err := net.ParseCIDR("192.168.21.100/31")
+		badip, _ := AddressRange(badipnet)
 		Expect(err).NotTo(HaveOccurred())
 
 		_, _, err = GetIPRange(badip, *badipnet)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(HavePrefix("Net mask is too short"))
+		Expect(err.Error()).To(HavePrefix("net mask is too short"))
 
 	})
 })

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -70,7 +70,7 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*types.IPAMConfig, string, er
 			jsonFile, err := os.Open(confpath)
 
 			if err != nil {
-				return nil, "", fmt.Errorf("Error opening flat configuration file @ %s with: %s", confpath, err)
+				return nil, "", fmt.Errorf("error opening flat configuration file @ %s with: %s", confpath, err)
 			}
 
 			defer jsonFile.Close()
@@ -160,7 +160,7 @@ func LoadIPAMConfig(bytes []byte, envArgs string) (*types.IPAMConfig, string, er
 	if n.IPAM.GatewayStr != "" {
 		gwip := net.ParseIP(n.IPAM.GatewayStr)
 		if gwip == nil {
-			return nil, "", fmt.Errorf("Couldn't parse gateway IP: %s", n.IPAM.GatewayStr)
+			return nil, "", fmt.Errorf("couldn't parse gateway IP: %s", n.IPAM.GatewayStr)
 		}
 		n.IPAM.Gateway = gwip
 	}

--- a/pkg/reconciler/iploop_test.go
+++ b/pkg/reconciler/iploop_test.go
@@ -122,7 +122,7 @@ var _ = Describe("IPReconciler", func() {
 
 			It("errors when attempting to clean up the IP address", func() {
 				reconciledIPs, err := ipReconciler.ReconcileIPPools(context.TODO())
-				Expect(err).To(MatchError(fmt.Sprintf("Did not find reserved IP for container %s", reservationPodRef)))
+				Expect(err).To(MatchError(fmt.Sprintf("did not find reserved IP for container %s", reservationPodRef)))
 				Expect(reconciledIPs).To(BeEmpty())
 			})
 		})
@@ -150,8 +150,4 @@ func generateIPReservation(ip string, podRef string) []types.IPReservation {
 			PodRef: podRef,
 		},
 	}
-}
-
-func generatePodRef(namespace, podName string) string {
-	return fmt.Sprintf("%s/%s", namespace, podName)
 }

--- a/pkg/storage/etcd.go
+++ b/pkg/storage/etcd.go
@@ -172,7 +172,7 @@ func IPManagementEtcd(ctx context.Context, mode int, ipamConf types.IPAMConfig, 
 	switch mode {
 	case types.Allocate, types.Deallocate:
 	default:
-		return newip, fmt.Errorf("Got an unknown mode passed to IPManagement: %v", mode)
+		return newip, fmt.Errorf("got an unknown mode passed to IPManagement: %v", mode)
 	}
 
 	var ipam Store

--- a/pkg/storage/kubernetes/client.go
+++ b/pkg/storage/kubernetes/client.go
@@ -108,11 +108,7 @@ func (i *Client) ListPods(ctx context.Context) ([]v1.Pod, error) {
 		return nil, err
 	}
 
-	var podEntries []v1.Pod
-	for _, pod := range podList.Items {
-		podEntries = append(podEntries, pod)
-	}
-	return podEntries, nil
+	return podList.Items, nil
 }
 
 func (i *Client) ListOverlappingIPs(ctx context.Context) ([]whereaboutsv1alpha1.OverlappingRangeIPReservation, error) {
@@ -121,11 +117,7 @@ func (i *Client) ListOverlappingIPs(ctx context.Context) ([]whereaboutsv1alpha1.
 		return nil, err
 	}
 
-	var clusterWiderReservations []whereaboutsv1alpha1.OverlappingRangeIPReservation
-	for _, reservationInfo := range overlappingIPsList.Items {
-		clusterWiderReservations = append(clusterWiderReservations, reservationInfo)
-	}
-	return clusterWiderReservations, nil
+	return overlappingIPsList.Items, nil
 }
 
 func (i *Client) DeleteOverlappingIP(ctx context.Context, clusterWideIP *whereaboutsv1alpha1.OverlappingRangeIPReservation) error {

--- a/pkg/storage/kubernetes/ipam.go
+++ b/pkg/storage/kubernetes/ipam.go
@@ -412,7 +412,7 @@ func IPManagementKubernetesUpdate(ctx context.Context, mode int, ipam *Kubernete
 	switch mode {
 	case whereaboutstypes.Allocate, whereaboutstypes.Deallocate:
 	default:
-		return newip, fmt.Errorf("Got an unknown mode passed to IPManagement: %v", mode)
+		return newip, fmt.Errorf("got an unknown mode passed to IPManagement: %v", mode)
 	}
 
 	var overlappingrangestore storage.OverlappingRangeStore
@@ -496,7 +496,7 @@ RETRYLOOP:
 		// Clean out any dummy records from the reservelist...
 		var usereservelist []whereaboutstypes.IPReservation
 		for _, rl := range updatedreservelist {
-			if rl.IsAllocated != true {
+			if !rl.IsAllocated {
 				usereservelist = append(usereservelist, rl)
 			}
 		}


### PR DESCRIPTION
Replace golint - which is deprecated - with the combination of `go vet` + `staticheck`, 
which is recommended by the `golint` project in their [readme](https://github.com/golang/lint#readme).
