### PR TITLE
build, dockerfiles: add reconciler

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -12,5 +12,6 @@ RUN ./hack/build-go.sh
 FROM arm64v8/alpine:latest
 LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/whereabouts
 COPY --from=0 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/whereabouts .
+COPY --from=0 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/ip-reconciler .
 COPY script/install-cni.sh .
 CMD ["/install-cni.sh"]

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -4,13 +4,15 @@ ADD . /go/src/github.com/k8snetworkplumbingwg/whereabouts
 WORKDIR /go/src/github.com/k8snetworkplumbingwg/whereabouts
 ENV CGO_ENABLED=1
 ENV GO111MODULE=on
-RUN go build -mod vendor -o bin/whereabouts cmd/whereabouts.go
+RUN go build -mod vendor -o bin/whereabouts     cmd/whereabouts.go
+RUN go build -mod vendor -o bin/ip-reconciler   cmd/reconciler/ip.go cmd/reconciler/errors.go
 WORKDIR /
 
 FROM openshift/origin-base
 RUN mkdir -p /usr/src/whereabouts/images && \
        mkdir -p /usr/src/whereabouts/bin
-COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/whereabouts /usr/src/whereabouts/bin
+COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/whereabouts   /usr/src/whereabouts/bin
+COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/ip-reconciler /usr/src/whereabouts/bin
 
 LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/whereabouts
 LABEL io.k8s.display-name="Whereabouts CNI" \


### PR DESCRIPTION
The ip-reconciler is only currently being shipped in the amd64 images.
This commit adds it to both the arm64 and openshift images, thus
aligning all of them.

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>