### PR TITLE
ip-reconciler: fix for duplicate IP allocation due

### DIFF
--- a/pkg/reconciler/iploop.go
+++ b/pkg/reconciler/iploop.go
@@ -48,14 +48,14 @@ func NewReconcileLooper(ctx context.Context, timeout int) (*ReconcileLooper, err
 }
 
 func newReconcileLooper(ctx context.Context, k8sClient *kubernetes.Client, timeout int) (*ReconcileLooper, error) {
-	pods, err := k8sClient.ListPods(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	ipPools, err := k8sClient.ListIPPools(ctx)
 	if err != nil {
 		return nil, logging.Errorf("failed to retrieve all IP pools: %v", err)
+	}
+
+	pods, err := k8sClient.ListPods(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	whereaboutsPodRefs := getPodRefsServedByWhereabouts(ipPools)


### PR DESCRIPTION
This change fetches the ip reservations first before fetching the pod
list for finding the stale reservations. This will help to overcome the
scenario where a new whereabout pod gets created between the time
reconciler fetches the pod and the reservations and ends up deleting the
reservation, eventually leading to duplicate IP.

#207 