### PR TITLE
ci, test: pin staticcheck 0.2.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       run: go vet ./...
 
     - name: Install static check
-      run: go install honnef.co/go/tools/cmd/staticcheck@latest
+      run: go install honnef.co/go/tools/cmd/staticcheck@v0.2.2
 
     - name: Test
       run: sudo PATH=${PATH}:./bin ./hack/test-go.sh


### PR DESCRIPTION
ci, test: pin staticcheck 0.2.2
    
The new `staticcheck` release - v0.3.0 - can only be installed on golang
1.17 or 1.18, since golang 1.16 already hit EOL.
    
This is tracked in issue [0].
    
A follow up PR should update whereabouts to use golang 1.17, but this PR
unlocks CI right now.
    
[0] - https://github.com/dominikh/go-tools/issues/1238
    
Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>
