### PR TITLE
ci: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# https://help.github.com/en/articles/about-code-owners
+* @dougbtv
+cmd/controlloop @maiqueb
+cmd/reconciler @maiqueb
+e2e/ @maiqueb
+pkg/reconciler/ @maiqueb
+


### PR DESCRIPTION
This way, new PRs are automatically added a reviewer from the list.

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>