### PR TITLE
Refactor ippool checker into struct

### DIFF
--- a/e2e/client/ippool.go
+++ b/e2e/client/ippool.go
@@ -1,7 +1,7 @@
 // This code is based on code from the following repository
 // https://github.com/bcreane/k8sutils
 
-package whereabouts_e2e
+package client
 
 import (
 	"context"

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -436,7 +436,7 @@ func checkZeroIPPoolAllocationsAndReplicas(clientInfo *wbtestclient.ClientInfo, 
 		return err
 	}
 
-	if err = WaitForZeroIPPoolAllocations(k8sIPAM, ipPoolName, zeroIPPoolTimeout); err != nil {
+	if err = wbtestclient.WaitForZeroIPPoolAllocations(k8sIPAM, ipPoolName, zeroIPPoolTimeout); err != nil {
 		return err
 	}
 

--- a/e2e/poolconsistency/checker.go
+++ b/e2e/poolconsistency/checker.go
@@ -1,0 +1,69 @@
+package poolconsistency
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/k8snetworkplumbingwg/whereabouts/e2e/retrievers"
+	"github.com/k8snetworkplumbingwg/whereabouts/pkg/storage"
+)
+
+type Checker struct {
+	ipPool  storage.IPPool
+	podList []corev1.Pod
+}
+
+func NewPoolConsistencyCheck(ipPool storage.IPPool, podList []corev1.Pod) *Checker {
+	return &Checker{
+		ipPool:  ipPool,
+		podList: podList,
+	}
+}
+
+func (pc *Checker) MissingIPs() []string {
+	var mismatchedIPs []string
+	for _, pod := range pc.podList {
+		podIP, err := retrievers.SecondaryIfaceIPValue(&pod)
+		if err != nil {
+			return []string{}
+		}
+
+		var found bool
+		for _, allocation := range pc.ipPool.Allocations() {
+			reservedIP := allocation.IP.String()
+
+			if reservedIP == podIP {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			mismatchedIPs = append(mismatchedIPs, podIP)
+		}
+	}
+	return mismatchedIPs
+}
+
+func (pc *Checker) StaleIPs() []string {
+	var staleIPs []string
+	for _, allocation := range pc.ipPool.Allocations() {
+		reservedIP := allocation.IP.String()
+		found := false
+		for _, pod := range pc.podList {
+			podIP, err := retrievers.SecondaryIfaceIPValue(&pod)
+			if err != nil {
+				continue
+			}
+
+			if reservedIP == podIP {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			staleIPs = append(staleIPs, allocation.IP.String())
+		}
+	}
+	return staleIPs
+}

--- a/e2e/poolconsistency/poolconsistency_test.go
+++ b/e2e/poolconsistency/poolconsistency_test.go
@@ -1,0 +1,148 @@
+package poolconsistency
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	k8snetplumbersv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
+	"github.com/k8snetworkplumbingwg/whereabouts/pkg/storage"
+	"github.com/k8snetworkplumbingwg/whereabouts/pkg/types"
+)
+
+func TestIPPoolConsistencyChecker(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Check IP Pool consistency")
+}
+
+var _ = Describe("IP Pool consistency checker", func() {
+	Context("Stale IPs", func() {
+		Context("empty IP pool", func() {
+			var (
+				pool storage.IPPool
+			)
+
+			BeforeEach(func() {
+				pool = NewMockedPool()
+			})
+
+			table.DescribeTable("does not have stale IPs", func(podList []corev1.Pod) {
+				Expect(NewPoolConsistencyCheck(pool, podList).StaleIPs()).To(BeEmpty())
+			},
+				table.Entry("without any live pod", []corev1.Pod{}),
+				table.Entry("independently of live pods", []corev1.Pod{
+					newPod("1", "2", "111.111.111.111"),
+				}))
+		})
+
+		Context("IP pool with allocations", func() {
+			const ip = "192.168.200.2"
+			var pool storage.IPPool
+
+			BeforeEach(func() {
+				pool = NewMockedPool(types.IPReservation{
+					IP:          net.ParseIP(ip),
+					ContainerID: "abc",
+					PodRef:      "cba",
+					IsAllocated: true,
+				})
+			})
+
+			It("an IP pool whose allocations point to live pods with different addresses", func() {
+				const staleIP = "192.168.123.200"
+				livePodList := []corev1.Pod{
+					newPod("pod", "default", staleIP),
+				}
+				Expect(NewPoolConsistencyCheck(pool, livePodList).StaleIPs()).To(ConsistOf(ip))
+			})
+		})
+	})
+
+	Context("Missing IPs", func() {
+		Context("no running pods", func() {
+			const ip = "192.168.200.2"
+
+			var podList []corev1.Pod
+
+			table.DescribeTable("does not have stale IPs", func(ipPool storage.IPPool) {
+				Expect(NewPoolConsistencyCheck(ipPool, podList).MissingIPs()).To(BeEmpty())
+			},
+				table.Entry("with an empty IPPool", NewMockedPool()),
+				table.Entry("even when the IPPool features allocations", NewMockedPool(
+					types.IPReservation{IP: net.ParseIP(ip)})))
+		})
+
+		Context("live pods whose IPs came from whereabouts", func() {
+			const ip = "192.168.200.2"
+
+			var livePodList []corev1.Pod
+
+			BeforeEach(func() {
+				livePodList = []corev1.Pod{newPod("1", "2", ip)}
+			})
+
+			It("a pool consistent with the live pods is free of missing IPs", func() {
+				Expect(
+					NewPoolConsistencyCheck(
+						NewMockedPool(ipReservation(ip)), livePodList).MissingIPs()).To(BeEmpty())
+			})
+
+			It("a pool that is *not* consistent with the live pods has missing IPs", func() {
+				const staleIP = "192.168.123.200"
+				Expect(
+					NewPoolConsistencyCheck(
+						NewMockedPool(ipReservation(staleIP)), livePodList).MissingIPs()).To(ConsistOf(ip))
+			})
+		})
+	})
+})
+
+func ipReservation(ipAddr string) types.IPReservation {
+	return types.IPReservation{IP: net.ParseIP(ipAddr)}
+}
+
+type mockedPool struct {
+	reservations []types.IPReservation
+}
+
+func NewMockedPool(ipReservations ...types.IPReservation) *mockedPool {
+	return &mockedPool{reservations: ipReservations}
+}
+
+func (mp *mockedPool) Allocations() []types.IPReservation {
+	return mp.reservations
+}
+
+func (mp *mockedPool) Update(context.Context, []types.IPReservation) error {
+	return nil
+}
+
+func newPod(name string, namespace string, ips ...string) corev1.Pod {
+	var ifaceStatus []k8snetplumbersv1.NetworkStatus
+	for i, ip := range ips {
+		ifaceStatus = append(ifaceStatus, k8snetplumbersv1.NetworkStatus{
+			Name:      fmt.Sprintf("net%d", i+1),
+			Interface: fmt.Sprintf("net%d", i+1),
+			IPs:       []string{ip},
+		})
+	}
+
+	serializedIfaceStatus, _ := json.Marshal(&ifaceStatus)
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: map[string]string{k8snetplumbersv1.NetworkStatusAnnot: string(serializedIfaceStatus)},
+		},
+	}
+}

--- a/e2e/retrievers/pod.go
+++ b/e2e/retrievers/pod.go
@@ -1,0 +1,46 @@
+package retrievers
+
+import (
+	"encoding/json"
+	"fmt"
+
+	core "k8s.io/api/core/v1"
+
+	nettypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+)
+
+func filterNetworkStatus(
+	networkStatuses []nettypes.NetworkStatus, predicate func(nettypes.NetworkStatus) bool) *nettypes.NetworkStatus {
+	for i, networkStatus := range networkStatuses {
+		if predicate(networkStatus) {
+			return &networkStatuses[i]
+		}
+	}
+	return nil
+}
+
+func SecondaryIfaceIPValue(pod *core.Pod) (string, error) {
+	podNetStatus, found := pod.Annotations[nettypes.NetworkStatusAnnot]
+	if !found {
+		return "", fmt.Errorf("the pod must feature the `networks-status` annotation")
+	}
+
+	var netStatus []nettypes.NetworkStatus
+	if err := json.Unmarshal([]byte(podNetStatus), &netStatus); err != nil {
+		return "", err
+	}
+
+	secondaryInterfaceNetworkStatus := filterNetworkStatus(netStatus, func(status nettypes.NetworkStatus) bool {
+		return status.Interface == "net1"
+	})
+
+	if secondaryInterfaceNetworkStatus == nil {
+		return "", fmt.Errorf("the pod does not have the requested secondary interface")
+	}
+
+	if len(secondaryInterfaceNetworkStatus.IPs) == 0 {
+		return "", fmt.Errorf("the pod does not have IPs for its secondary interfaces")
+	}
+
+	return secondaryInterfaceNetworkStatus.IPs[0], nil
+}


### PR DESCRIPTION
This PR moves the IPPool checks to a dedicated pkg.
    
It furthermore redesigns the pool consistency checks to use a struct, thus allowing
developers to write tests in the following way:

```go
Expect(
    poolconsistency.NewPoolConsistencyCheck(
        ipPool, podList.Items).MissingIPs()).To(BeEmpty())
Expect(
    poolconsistency.NewPoolConsistencyCheck(
        ipPool, podList.Items).StaleIPs()).To(BeEmpty())
```
instead of what is used currently:
```go
 Expect(
    iPPoolConsistency(
        k8sIPAM,
        clientInfo.Client,
        testNamespace,
        ipPoolName,
        entities.ReplicaSetQuery(rsName))).To(Succeed())
```

The implementation above does offer more information on failures, and is
more ginkgo native than the current approach.
