### PR TITLE
reconciler, shutdown: export shutdown into a func

### DIFF
--- a/cmd/controlloop/main.go
+++ b/cmd/controlloop/main.go
@@ -56,6 +56,9 @@ func main() {
 	}
 
 	networkController.Start(stopChan)
+	defer networkController.Shutdown()
+	<-stopChan
+	logging.Verbosef("shutting down network controller")
 }
 
 func handleSignals(stopChannel chan struct{}, signals ...os.Signal) {

--- a/pkg/reconciler/controlloop/pod.go
+++ b/pkg/reconciler/controlloop/pod.go
@@ -109,16 +109,17 @@ func newPodController(k8sCoreInformerFactory v1coreinformerfactory.SharedInforme
 // Start runs worker thread after performing cache synchronization
 func (pc *PodController) Start(stopChan <-chan struct{}) {
 	logging.Verbosef("starting network controller")
-	defer pc.workqueue.ShutDown()
 
 	if ok := cache.WaitForCacheSync(stopChan, pc.arePodsSynched, pc.areNetAttachDefsSynched, pc.areIPPoolsSynched); !ok {
 		logging.Verbosef("failed waiting for caches to sync")
 	}
 
 	go wait.Until(pc.worker, syncPeriod, stopChan)
+}
 
-	<-stopChan
-	logging.Verbosef("shutting down network controller")
+// Shutdown stops the PodController worker queue
+func (pc *PodController) Shutdown() {
+	pc.workqueue.ShutDown()
 }
 
 func (pc *PodController) worker() {


### PR DESCRIPTION
This prepares the ground for a coordinated shutdown of the reconciler
worker queue triggered from the main reconciler func.

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>