### PR TITLE
Propose issue templates for bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Report a bug and help us improve
+title: "[BUG]"
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. 
+2. 
+3.
+
+**Environment**:
+- Whereabouts version : N/A
+- Kubernetes version (use `kubectl version`): N/A
+- Network-attachment-definition: N/A
+- Whereabouts configuration (on the host): N/A
+- OS (e.g. from /etc/os-release): N/A
+- Kernel (e.g. `uname -a`): N/A
+- Others: N/A
+
+**Additional info / context**
+Add any other information / context about the problem here.


### PR DESCRIPTION
An issue template will help the community to know what information is required for a bug.

This will improve the triage procedure, and reduce the back n' forth of the maintainers (no need to ask for info...).
