### PR TITLE
[WIP] Add support for dualstack / multiple IP ranges 

### DIFF
--- a/pkg/allocate/allocate.go
+++ b/pkg/allocate/allocate.go
@@ -21,7 +21,7 @@ func (a AssignmentError) Error() string {
 }
 
 // AssignIP assigns an IP using a range and a reserve list.
-func AssignIP(ipamConf types.IPAMConfig, reservelist []types.IPReservation, containerID string, podRef string) (net.IPNet, []types.IPReservation, error) {
+func AssignIP(ipamConf types.RangeConfiguration, reservelist []types.IPReservation, containerID string, podRef string) (net.IPNet, []types.IPReservation, error) {
 
 	// Setup the basics here.
 	_, ipnet, _ := net.ParseCIDR(ipamConf.Range)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -111,30 +111,32 @@ func LoadIPAMConfig(bytes []byte, envArgs string, extraConfigPaths ...string) (*
 		logging.Debugf("Used defaults from parsed flat file config @ %s", foundflatfile)
 	}
 
-	if r := strings.SplitN(n.IPAM.Range, "-", 2); len(r) == 2 {
-		firstip := net.ParseIP(r[0])
-		if firstip == nil {
-			return nil, "", fmt.Errorf("invalid range start IP: %s", r[0])
-		}
-		lastip, ipNet, err := net.ParseCIDR(r[1])
-		if err != nil {
-			return nil, "", fmt.Errorf("invalid CIDR (do you have the 'range' parameter set for Whereabouts?) '%s': %s", r[1], err)
-		}
-		if !ipNet.Contains(firstip) {
-			return nil, "", fmt.Errorf("invalid range start for CIDR %s: %s", ipNet.String(), firstip)
-		}
-		n.IPAM.Range = ipNet.String()
-		n.IPAM.RangeStart = firstip
-		n.IPAM.RangeEnd = lastip
-	} else {
-		firstip, ipNet, err := net.ParseCIDR(n.IPAM.Range)
-		if err != nil {
-			return nil, "", fmt.Errorf("invalid CIDR %s: %s", n.IPAM.Range, err)
-		}
-		n.IPAM.Range = ipNet.String()
-		if n.IPAM.RangeStart == nil {
-			firstip = net.ParseIP(firstip.Mask(ipNet.Mask).String()) // if range_start is not net then pick the first network address
-			n.IPAM.RangeStart = firstip
+	for idx, _ := range n.IPAM.IPRanges {
+		if r := strings.SplitN(n.IPAM.IPRanges[idx].Range, "-", 2); len(r) == 2 {
+			firstip := net.ParseIP(r[0])
+			if firstip == nil {
+				return nil, "", fmt.Errorf("invalid range start IP: %s", r[0])
+			}
+			lastip, ipNet, err := net.ParseCIDR(r[1])
+			if err != nil {
+				return nil, "", fmt.Errorf("invalid CIDR (do you have the 'range' parameter set for Whereabouts?) '%s': %s", r[1], err)
+			}
+			if !ipNet.Contains(firstip) {
+				return nil, "", fmt.Errorf("invalid range start for CIDR %s: %s", ipNet.String(), firstip)
+			}
+			n.IPAM.IPRanges[idx].Range = ipNet.String()
+			n.IPAM.IPRanges[idx].RangeStart = firstip
+			n.IPAM.IPRanges[idx].RangeEnd = lastip
+		} else {
+			firstip, ipNet, err := net.ParseCIDR(n.IPAM.IPRanges[idx].Range)
+			if err != nil {
+				return nil, "", fmt.Errorf("invalid CIDR %s: %s", n.IPAM.IPRanges[idx].Range, err)
+			}
+			n.IPAM.Range = ipNet.String()
+			if n.IPAM.IPRanges[idx].RangeStart == nil {
+				firstip = net.ParseIP(firstip.Mask(ipNet.Mask).String()) // if range_start is not net then pick the first network address
+				n.IPAM.IPRanges[idx].RangeStart = firstip
+			}
 		}
 	}
 

--- a/pkg/reconciler/controlloop/pod.go
+++ b/pkg/reconciler/controlloop/pod.go
@@ -45,7 +45,7 @@ const (
 	addressGarbageCollectionFailed = "IPAddressGarbageCollectionFailed"
 )
 
-type garbageCollector func(ctx context.Context, mode int, ipamConf types.IPAMConfig, containerID string, podRef string) (net.IPNet, error)
+type garbageCollector func(ctx context.Context, mode int, ipamConf types.IPAMConfig, containerID string, podRef string) ([]net.IPNet, error)
 
 type PodController struct {
 	arePodsSynched          cache.InformerSynced

--- a/pkg/storage/kubernetes/ipam.go
+++ b/pkg/storage/kubernetes/ipam.go
@@ -352,17 +352,17 @@ func newLeaderElector(clientset *kubernetes.Clientset, namespace string, podName
 }
 
 // IPManagement manages ip allocation and deallocation from a storage perspective
-func IPManagement(ctx context.Context, mode int, ipamConf whereaboutstypes.IPAMConfig, containerID string, podRef string) (net.IPNet, error) {
-	var newip net.IPNet
+func IPManagement(ctx context.Context, mode int, ipamConf whereaboutstypes.IPAMConfig, containerID string, podRef string) ([]net.IPNet, error) {
+	var newips []net.IPNet
 
 	ipam, err := NewKubernetesIPAM(containerID, ipamConf)
 	if err != nil {
-		return newip, logging.Errorf("IPAM %s client initialization error: %v", ipamConf.Datastore, err)
+		return newips, logging.Errorf("IPAM %s client initialization error: %v", ipamConf.Datastore, err)
 	}
 	defer ipam.Close()
 
 	if ipamConf.PodName == "" {
-		return newip, fmt.Errorf("IPAM %s client initialization error: no pod name", ipamConf.Datastore)
+		return newips, fmt.Errorf("IPAM %s client initialization error: no pod name", ipamConf.Datastore)
 	}
 
 	// setup leader election
@@ -383,7 +383,7 @@ func IPManagement(ctx context.Context, mode int, ipamConf whereaboutstypes.IPAMC
 				return
 			case <-leader:
 				logging.Debugf("Elected as leader, do processing")
-				newip, err = IPManagementKubernetesUpdate(ctx, mode, ipam, ipamConf, containerID, podRef)
+				newips, err = IPManagementKubernetesUpdate(ctx, mode, ipam, ipamConf, containerID, podRef)
 				stopM <- struct{}{}
 				return
 			case <-deposed:
@@ -415,21 +415,22 @@ func IPManagement(ctx context.Context, mode int, ipamConf whereaboutstypes.IPAMC
 
 	wg.Wait()
 	close(stopM)
-	logging.Debugf("IPManagement: %v, %v", newip, err)
-	return newip, err
+	logging.Debugf("IPManagement: %v, %v", newips, err)
+	return newips, err
 }
 
 // IPManagementKubernetesUpdate manages k8s updates
 func IPManagementKubernetesUpdate(ctx context.Context, mode int, ipam *KubernetesIPAM, ipamConf whereaboutstypes.IPAMConfig,
-	containerID string, podRef string) (net.IPNet, error) {
+	containerID string, podRef string) ([]net.IPNet, error) {
 	logging.Debugf("IPManagement -- mode: %v / containerID: %v / podRef: %v", mode, containerID, podRef)
 
+	var newips []net.IPNet
 	var newip net.IPNet
 	// Skip invalid modes
 	switch mode {
 	case whereaboutstypes.Allocate, whereaboutstypes.Deallocate:
 	default:
-		return newip, fmt.Errorf("got an unknown mode passed to IPManagement: %v", mode)
+		return newips, fmt.Errorf("got an unknown mode passed to IPManagement: %v", mode)
 	}
 
 	var overlappingrangestore storage.OverlappingRangeStore
@@ -442,107 +443,110 @@ func IPManagementKubernetesUpdate(ctx context.Context, mode int, ipam *Kubernete
 	// Check our connectivity first
 	if err := ipam.Status(requestCtx); err != nil {
 		logging.Errorf("IPAM connectivity error: %v", err)
-		return newip, err
+		return newips, err
 	}
 
 	// handle the ip add/del until successful
 	var overlappingrangeallocations []whereaboutstypes.IPReservation
 	var ipforoverlappingrangeupdate net.IP
-RETRYLOOP:
-	for j := 0; j < storage.DatastoreRetries; j++ {
-		select {
-		case <-ctx.Done():
-			return newip, err
-		default:
-			// retry the IPAM loop if the context has not been cancelled
-		}
-
-		overlappingrangestore, err = ipam.GetOverlappingRangeStore()
-		if err != nil {
-			logging.Errorf("IPAM error getting OverlappingRangeStore: %v", err)
-			return newip, err
-		}
-
-		pool, err = ipam.GetIPPool(requestCtx, ipamConf.Range)
-		if err != nil {
-			logging.Errorf("IPAM error reading pool allocations (attempt: %d): %v", j, err)
-			if e, ok := err.(storage.Temporary); ok && e.Temporary() {
-				continue
+	for _, ipRange := range ipamConf.IPRanges {
+	RETRYLOOP:
+		for j := 0; j < storage.DatastoreRetries; j++ {
+			select {
+			case <-ctx.Done():
+				break RETRYLOOP
+			default:
+				// retry the IPAM loop if the context has not been cancelled
 			}
-			return newip, err
-		}
 
-		reservelist := pool.Allocations()
-		reservelist = append(reservelist, overlappingrangeallocations...)
-		var updatedreservelist []whereaboutstypes.IPReservation
-		switch mode {
-		case whereaboutstypes.Allocate:
-			newip, updatedreservelist, err = allocate.AssignIP(ipamConf, reservelist, containerID, podRef)
+			overlappingrangestore, err = ipam.GetOverlappingRangeStore()
 			if err != nil {
-				logging.Errorf("Error assigning IP: %v", err)
-				return newip, err
+				logging.Errorf("IPAM error getting OverlappingRangeStore: %v", err)
+				return newips, err
 			}
-			// Now check if this is allocated overlappingrange wide
-			// When it's allocated overlappingrange wide, we add it to a local reserved list
-			// And we try again.
-			if ipamConf.OverlappingRanges {
-				isallocated, err := overlappingrangestore.IsAllocatedInOverlappingRange(requestCtx, newip.IP)
-				if err != nil {
-					logging.Errorf("Error checking overlappingrange allocation: %v", err)
-					return newip, err
-				}
 
-				if isallocated {
-					logging.Debugf("Continuing loop, IP is already allocated (possibly from another range): %v", newip)
-					// We create "dummy" records here for evaluation, but, we need to filter those out later.
-					overlappingrangeallocations = append(overlappingrangeallocations, whereaboutstypes.IPReservation{IP: newip.IP, IsAllocated: true})
+			pool, err = ipam.GetIPPool(requestCtx, ipRange.Range)
+			if err != nil {
+				logging.Errorf("IPAM error reading pool allocations (attempt: %d): %v", j, err)
+				if e, ok := err.(storage.Temporary); ok && e.Temporary() {
 					continue
 				}
-
-				ipforoverlappingrangeupdate = newip.IP
+				return newips, err
 			}
 
-		case whereaboutstypes.Deallocate:
-			updatedreservelist, ipforoverlappingrangeupdate, err = allocate.DeallocateIP(reservelist, containerID)
+			reservelist := pool.Allocations()
+			reservelist = append(reservelist, overlappingrangeallocations...)
+			var updatedreservelist []whereaboutstypes.IPReservation
+			switch mode {
+			case whereaboutstypes.Allocate:
+				newip, updatedreservelist, err = allocate.AssignIP(ipRange, reservelist, containerID, podRef)
+				if err != nil {
+					logging.Errorf("Error assigning IP: %v", err)
+					return newips, err
+				}
+				// Now check if this is allocated overlappingrange wide
+				// When it's allocated overlappingrange wide, we add it to a local reserved list
+				// And we try again.
+				if ipamConf.OverlappingRanges {
+					isallocated, err := overlappingrangestore.IsAllocatedInOverlappingRange(requestCtx, newip.IP)
+					if err != nil {
+						logging.Errorf("Error checking overlappingrange allocation: %v", err)
+						return newips, err
+					}
+
+					if isallocated {
+						logging.Debugf("Continuing loop, IP is already allocated (possibly from another range): %v", newip)
+						// We create "dummy" records here for evaluation, but, we need to filter those out later.
+						overlappingrangeallocations = append(overlappingrangeallocations, whereaboutstypes.IPReservation{IP: newip.IP, IsAllocated: true})
+						continue
+					}
+
+					ipforoverlappingrangeupdate = newip.IP
+				}
+
+			case whereaboutstypes.Deallocate:
+				updatedreservelist, ipforoverlappingrangeupdate, err = allocate.DeallocateIP(reservelist, containerID)
+				if err != nil {
+					logging.Errorf("Error deallocating IP: %v", err)
+					return newips, err
+				}
+			}
+
+			// Clean out any dummy records from the reservelist...
+			var usereservelist []whereaboutstypes.IPReservation
+			for _, rl := range updatedreservelist {
+				if !rl.IsAllocated {
+					usereservelist = append(usereservelist, rl)
+				}
+			}
+
+			// Manual race condition testing
+			if ipamConf.SleepForRace > 0 {
+				time.Sleep(time.Duration(ipamConf.SleepForRace) * time.Second)
+			}
+
+			err = pool.Update(requestCtx, usereservelist)
 			if err != nil {
-				logging.Errorf("Error deallocating IP: %v", err)
-				return newip, err
-			}
-		}
-
-		// Clean out any dummy records from the reservelist...
-		var usereservelist []whereaboutstypes.IPReservation
-		for _, rl := range updatedreservelist {
-			if !rl.IsAllocated {
-				usereservelist = append(usereservelist, rl)
-			}
-		}
-
-		// Manual race condition testing
-		if ipamConf.SleepForRace > 0 {
-			time.Sleep(time.Duration(ipamConf.SleepForRace) * time.Second)
-		}
-
-		err = pool.Update(requestCtx, usereservelist)
-		if err != nil {
-			logging.Errorf("IPAM error updating pool (attempt: %d): %v", j, err)
-			if e, ok := err.(storage.Temporary); ok && e.Temporary() {
-				continue
+				logging.Errorf("IPAM error updating pool (attempt: %d): %v", j, err)
+				if e, ok := err.(storage.Temporary); ok && e.Temporary() {
+					continue
+				}
+				break RETRYLOOP
 			}
 			break RETRYLOOP
 		}
-		break RETRYLOOP
-	}
 
-	if ipamConf.OverlappingRanges {
-		err = overlappingrangestore.UpdateOverlappingRangeAllocation(requestCtx, mode, ipforoverlappingrangeupdate, containerID, podRef)
-		if err != nil {
-			logging.Errorf("Error performing UpdateOverlappingRangeAllocation: %v", err)
-			return newip, err
+		if ipamConf.OverlappingRanges {
+			err = overlappingrangestore.UpdateOverlappingRangeAllocation(requestCtx, mode, ipforoverlappingrangeupdate, containerID, podRef)
+			if err != nil {
+				logging.Errorf("Error performing UpdateOverlappingRangeAllocation: %v", err)
+				return newips, err
+			}
 		}
-	}
 
-	return newip, err
+		newips = append(newips, newip)
+	}
+	return newips, err
 }
 
 func wbNamespaceFromCtx(ctx *clientcmdapi.Context) string {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -47,29 +47,30 @@ type RangeConfiguration struct {
 // IPAMConfig describes the expected json configuration for this plugin
 type IPAMConfig struct {
 	Name                string
-	Type                string            `json:"type"`
-	Routes              []*cnitypes.Route `json:"routes"`
-	Datastore           string            `json:"datastore"`
-	Addresses           []Address         `json:"addresses,omitempty"`
-	OmitRanges          []string          `json:"exclude,omitempty"`
-	DNS                 cnitypes.DNS      `json:"dns"`
-	Range               string            `json:"range"`
-	RangeStart          net.IP            `json:"range_start,omitempty"`
-	RangeEnd            net.IP            `json:"range_end,omitempty"`
-	GatewayStr          string            `json:"gateway"`
-	EtcdHost            string            `json:"etcd_host,omitempty"`
-	EtcdUsername        string            `json:"etcd_username,omitempty"`
-	EtcdPassword        string            `json:"etcd_password,omitempty"`
-	EtcdKeyFile         string            `json:"etcd_key_file,omitempty"`
-	EtcdCertFile        string            `json:"etcd_cert_file,omitempty"`
-	EtcdCACertFile      string            `json:"etcd_ca_cert_file,omitempty"`
-	LeaderLeaseDuration int               `json:"leader_lease_duration,omitempty"`
-	LeaderRenewDeadline int               `json:"leader_renew_deadline,omitempty"`
-	LeaderRetryPeriod   int               `json:"leader_retry_period,omitempty"`
-	LogFile             string            `json:"log_file"`
-	LogLevel            string            `json:"log_level"`
-	OverlappingRanges   bool              `json:"enable_overlapping_ranges,omitempty"`
-	SleepForRace        int               `json:"sleep_for_race,omitempty"`
+	Type                string               `json:"type"`
+	Routes              []*cnitypes.Route    `json:"routes"`
+	Datastore           string               `json:"datastore"`
+	Addresses           []Address            `json:"addresses,omitempty"`
+	OmitRanges          []string             `json:"exclude,omitempty"`
+	IPRanges            []RangeConfiguration `json:"ipRanges"`
+	DNS                 cnitypes.DNS         `json:"dns"`
+	Range               string               `json:"range"`
+	RangeStart          net.IP               `json:"range_start,omitempty"`
+	RangeEnd            net.IP               `json:"range_end,omitempty"`
+	GatewayStr          string               `json:"gateway"`
+	EtcdHost            string               `json:"etcd_host,omitempty"`
+	EtcdUsername        string               `json:"etcd_username,omitempty"`
+	EtcdPassword        string               `json:"etcd_password,omitempty"`
+	EtcdKeyFile         string               `json:"etcd_key_file,omitempty"`
+	EtcdCertFile        string               `json:"etcd_cert_file,omitempty"`
+	EtcdCACertFile      string               `json:"etcd_ca_cert_file,omitempty"`
+	LeaderLeaseDuration int                  `json:"leader_lease_duration,omitempty"`
+	LeaderRenewDeadline int                  `json:"leader_renew_deadline,omitempty"`
+	LeaderRetryPeriod   int                  `json:"leader_retry_period,omitempty"`
+	LogFile             string               `json:"log_file"`
+	LogLevel            string               `json:"log_level"`
+	OverlappingRanges   bool                 `json:"enable_overlapping_ranges,omitempty"`
+	SleepForRace        int                  `json:"sleep_for_race,omitempty"`
 	Gateway             net.IP
 	Kubernetes          KubernetesConfig `json:"kubernetes,omitempty"`
 	ConfigurationPath   string           `json:"configuration_path"`

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -36,6 +36,14 @@ type NetConfList struct {
 	Plugins      []*Net `json:"plugins,omitempty"`
 }
 
+type RangeConfiguration struct {
+	Addresses  []Address `json:"addresses,omitempty"`
+	OmitRanges []string  `json:"exclude,omitempty"`
+	Range      string    `json:"range"`
+	RangeStart net.IP    `json:"range_start,omitempty"`
+	RangeEnd   net.IP    `json:"range_end,omitempty"`
+}
+
 // IPAMConfig describes the expected json configuration for this plugin
 type IPAMConfig struct {
 	Name                string


### PR DESCRIPTION
# New Feature

## Motivation

This PR adds support for IPv4/IPv6 dual-stack and multiple IP assignment

Feature proposal: #237 

## Changes

- Introduced a new type `RangeConfiguration` in `pkg/types/types.go` for encapsulating configurations of range for IP assignment
- Add new field `IPRanges  []RangeConfiguration` in `IPAMConfig` for handling multiple IP ranges
- Update `config.go` to work with `IPRanges` instead of `IPAM.Range, ...`
- Use `RangeConfiguration` in `allocate.AssignIP` instead of `IPAMConfig`
- Integrate `IPRanges` with etcd's IP Management
- Integrate `IPRanges` with kubernetes' IP Management
- Update whereabouts' logic to assign multiple new IPs to a pod based on a list of new IPs returned by IP Management module
- Update function definition of `garbageCollector` to match with the changes in definition of `wbclient.IPManagement`

## Tasks

### Project management

- [x] Created a related issue
- [ ] Added proper labels to the issue @dougbtv 
- [ ] Assigned yourself as the assignee @dougbtv 
- [x] Created a PR for design proposal
- [ ] Finalized and merged design proposal @dougbtv @maiqueb 

### Code management

- [x] Update IPAM structure
- [ ] Backward compatibility
- [x] Add feature to support dual-stack
- [x] Add feature to support multiple IP ranges
- [x] Manual testing for above feature
- [ ] Update old test cases
- [ ] Add new test cases for the added features
- [ ] Update documentation
- [x] Checked for mistakenly committed files

Closes #212 

