### PR TITLE
build: use tagged released versions for v0.5

### DIFF
--- a/doc/crds/daemonset-install.yaml
+++ b/doc/crds/daemonset-install.yaml
@@ -101,7 +101,7 @@ spec:
           - >
             SLEEP=false /install-cni.sh &&
             /ip-control-loop -log-level debug
-        image: ghcr.io/k8snetworkplumbingwg/whereabouts:latest-amd64
+        image: ghcr.io/k8snetworkplumbingwg/whereabouts:v0.5.3-amd64
         env:
         - name: WHEREABOUTS_NAMESPACE
           valueFrom:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->

**What this PR does / why we need it**:
This PR aligns the 0.5 release to use the latest released docker img, instead of the latest img generated from master.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #252 

**Special notes for your reviewer** *(optional)*:

