### PR TITLE
Implement network name

### DIFF
--- a/cmd/whereabouts_test.go
+++ b/cmd/whereabouts_test.go
@@ -57,7 +57,7 @@ func AllocateAndReleaseAddressesTest(ipVersion string, ipamConf *whereaboutstype
 	Expect(ipamConf.IPRanges).NotTo(BeEmpty())
 	wbClient := *kubernetes.NewKubernetesClient(
 		fake.NewSimpleClientset(
-			ipPool(ipamConf.IPRanges[0].Range, podNamespace)),
+			ipPool(ipamConf.IPRanges[0].Range, podNamespace, ipamConf.NetworkName)),
 		fakek8sclient.NewSimpleClientset(),
 		0)
 	for i := 0; i < len(expectedAddresses); i++ {
@@ -123,7 +123,7 @@ func AllocateAndReleaseAddressesTest(ipVersion string, ipamConf *whereaboutstype
 				ipamConf,
 				fakek8sclient.NewSimpleClientset(),
 				fake.NewSimpleClientset(
-					ipPool(ipamConf.IPRanges[0].Range, podNamespace)))
+					ipPool(ipamConf.IPRanges[0].Range, podNamespace, ipamConf.NetworkName)))
 			return cmdDel(args, client)
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -315,7 +315,7 @@ var _ = Describe("Whereabouts operations", func() {
 			ipamConf,
 			fakek8sclient.NewSimpleClientset(),
 			fake.NewSimpleClientset(
-				ipPool(ipamConf.IPRanges[0].Range, podNamespace)))
+				ipPool(ipamConf.IPRanges[0].Range, podNamespace, ipamConf.NetworkName)))
 
 		// Allocate the IP
 		r, raw, err := testutils.CmdAddWithArgs(args, func() error {
@@ -387,7 +387,7 @@ var _ = Describe("Whereabouts operations", func() {
 			ipamConf,
 			fakek8sclient.NewSimpleClientset(),
 			fake.NewSimpleClientset(
-				ipPool(ipamConf.IPRanges[0].Range, podNamespace)))
+				ipPool(ipamConf.IPRanges[0].Range, podNamespace, ipamConf.NetworkName)))
 
 		// Allocate the IP
 		r, raw, err := testutils.CmdAddWithArgs(args, func() error {
@@ -456,7 +456,7 @@ var _ = Describe("Whereabouts operations", func() {
 			ipamConf,
 			fakek8sclient.NewSimpleClientset(),
 			fake.NewSimpleClientset(
-				ipPool(ipamConf.IPRanges[0].Range, podNamespace)))
+				ipPool(ipamConf.IPRanges[0].Range, podNamespace, ipamConf.NetworkName)))
 
 		// Allocate the IP
 		r, raw, err := testutils.CmdAddWithArgs(args, func() error {
@@ -536,7 +536,7 @@ var _ = Describe("Whereabouts operations", func() {
 			ipamConf,
 			fakek8sclient.NewSimpleClientset(),
 			fake.NewSimpleClientset(
-				ipPool(ipamConf.IPRanges[0].Range, podNamespace)))
+				ipPool(ipamConf.IPRanges[0].Range, podNamespace, ipamConf.NetworkName)))
 
 		// Allocate the IP
 		r, raw, err := testutils.CmdAddWithArgs(args, func() error {
@@ -625,7 +625,7 @@ var _ = Describe("Whereabouts operations", func() {
 			ipamConf,
 			fakek8sclient.NewSimpleClientset(),
 			fake.NewSimpleClientset(
-				ipPool(ipamConf.IPRanges[0].Range, podNamespace)))
+				ipPool(ipamConf.IPRanges[0].Range, podNamespace, ipamConf.NetworkName)))
 
 		// Allocate the IP
 		r, raw, err := testutils.CmdAddWithArgs(args, func() error {
@@ -689,8 +689,8 @@ var _ = Describe("Whereabouts operations", func() {
 			ipamConf,
 			fakek8sclient.NewSimpleClientset(),
 			fake.NewSimpleClientset(
-				ipPool(ipamConf.IPRanges[0].Range, podNamespace),
-				ipPool(ipamConf.IPRanges[1].Range, podNamespace)))
+				ipPool(ipamConf.IPRanges[0].Range, podNamespace, ipamConf.NetworkName),
+				ipPool(ipamConf.IPRanges[1].Range, podNamespace, ipamConf.NetworkName)))
 
 		// Allocate the IP
 		r, raw, err := testutils.CmdAddWithArgs(args, func() error {
@@ -754,8 +754,8 @@ var _ = Describe("Whereabouts operations", func() {
 			ipamConf,
 			fakek8sclient.NewSimpleClientset(),
 			fake.NewSimpleClientset(
-				ipPool(ipamConf.IPRanges[0].Range, podNamespace),
-				ipPool(ipamConf.IPRanges[1].Range, podNamespace)))
+				ipPool(ipamConf.IPRanges[0].Range, podNamespace, ipamConf.NetworkName),
+				ipPool(ipamConf.IPRanges[1].Range, podNamespace, ipamConf.NetworkName)))
 
 		// Allocate the IP
 		r, raw, err := testutils.CmdAddWithArgs(args, func() error {
@@ -817,7 +817,7 @@ var _ = Describe("Whereabouts operations", func() {
 			ipamConf,
 			fakek8sclient.NewSimpleClientset(),
 			fake.NewSimpleClientset(
-				ipPool(ipamConf.IPRanges[0].Range, podNamespace)))
+				ipPool(ipamConf.IPRanges[0].Range, podNamespace, ipamConf.NetworkName)))
 
 		// Allocate the IP
 		r, raw, err := testutils.CmdAddWithArgs(args, func() error {
@@ -883,7 +883,7 @@ var _ = Describe("Whereabouts operations", func() {
 			ipamConf,
 			fakek8sclient.NewSimpleClientset(),
 			fake.NewSimpleClientset(
-				ipPool(ipamConf.IPRanges[0].Range, podNamespace)))
+				ipPool(ipamConf.IPRanges[0].Range, podNamespace, ipamConf.NetworkName)))
 
 		// Allocate the IP
 		r, raw, err := testutils.CmdAddWithArgs(args, func() error {
@@ -939,7 +939,7 @@ var _ = Describe("Whereabouts operations", func() {
 		Expect(ipamConf.IPRanges).NotTo(BeEmpty())
 		wbClient := *kubernetes.NewKubernetesClient(
 			fake.NewSimpleClientset(
-				ipPool(ipamConf.IPRanges[0].Range, podNamespace)),
+				ipPool(ipamConf.IPRanges[0].Range, podNamespace, ipamConf.NetworkName)),
 			fakek8sclient.NewSimpleClientset(),
 			0)
 
@@ -1036,7 +1036,7 @@ var _ = Describe("Whereabouts operations", func() {
 		Expect(ipamConf.IPRanges).NotTo(BeEmpty())
 		wbClient := *kubernetes.NewKubernetesClient(
 			fake.NewSimpleClientset(
-				ipPool(ipamConf.IPRanges[0].Range, podNamespace)),
+				ipPool(ipamConf.IPRanges[0].Range, podNamespace, ipamConf.NetworkName)),
 			fakek8sclient.NewSimpleClientset(),
 			0)
 
@@ -1154,7 +1154,7 @@ var _ = Describe("Whereabouts operations", func() {
 		Expect(ipamConf.IPRanges).NotTo(BeEmpty())
 		wbClient := *kubernetes.NewKubernetesClient(
 			fake.NewSimpleClientset(
-				ipPool(ipamConf.IPRanges[0].Range, podNamespace)),
+				ipPool(ipamConf.IPRanges[0].Range, podNamespace, ipamConf.NetworkName)),
 			fakek8sclient.NewSimpleClientset(),
 			0)
 
@@ -1273,7 +1273,7 @@ var _ = Describe("Whereabouts operations", func() {
 		Expect(ipamConf.IPRanges).NotTo(BeEmpty())
 		wbClient := *kubernetes.NewKubernetesClient(
 			fake.NewSimpleClientset(
-				ipPool(ipamConf.IPRanges[0].Range, podNamespace)),
+				ipPool(ipamConf.IPRanges[0].Range, podNamespace, ipamConf.NetworkName)),
 			fakek8sclient.NewSimpleClientset(),
 			0)
 
@@ -1452,10 +1452,10 @@ users:
 `)
 }
 
-func ipPool(ipRange string, namespace string, podReferences ...string) *v1alpha1.IPPool {
+func ipPool(ipRange string, namespace string, networkName string, podReferences ...string) *v1alpha1.IPPool {
 	return &v1alpha1.IPPool{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            kubernetes.NormalizeRange(ipRange),
+			Name:            kubernetes.IPPoolName(kubernetes.PoolIdentifier{IpRange: ipRange, NetworkName: networkName}),
 			Namespace:       namespace,
 			ResourceVersion: "1",
 		},

--- a/doc/proposals/named-networks.md
+++ b/doc/proposals/named-networks.md
@@ -1,5 +1,7 @@
 # Support for named networks
 
+It was decided in March 2023 to implement scheme 3. This means that we added a new field to the `IPAMConfig` called `network_name` that is included in the `IPPool` name to distinguish it from other pools with the same CIDR.
+
 # Table of contents
 
 - [Introduction](#introduction)

--- a/e2e/client/ippool.go
+++ b/e2e/client/ippool.go
@@ -13,9 +13,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-func isIPPoolAllocationsEmpty(k8sIPAM *kubeClient.KubernetesIPAM, ipPoolName string) wait.ConditionFunc {
+func isIPPoolAllocationsEmpty(k8sIPAM *kubeClient.KubernetesIPAM, ipPoolCIDR string) wait.ConditionFunc {
 	return func() (bool, error) {
-		ipPool, err := k8sIPAM.GetIPPool(context.Background(), ipPoolName)
+		ipPool, err := k8sIPAM.GetIPPool(context.Background(), kubeClient.PoolIdentifier{IpRange: ipPoolCIDR, NetworkName: kubeClient.UnnamedNetwork})
 		noPoolError := fmt.Errorf("k8s pool initialized")
 		if errors.Is(err, noPoolError) {
 			return true, nil
@@ -33,6 +33,6 @@ func isIPPoolAllocationsEmpty(k8sIPAM *kubeClient.KubernetesIPAM, ipPoolName str
 
 // WaitForZeroIPPoolAllocations polls up to timeout seconds for IP pool allocations to be gone from the Kubernetes cluster.
 // Returns an error if any IP pool allocations remain after time limit, or if GETing IP pools causes an error.
-func WaitForZeroIPPoolAllocations(k8sIPAM *kubeClient.KubernetesIPAM, ipPoolName string, timeout time.Duration) error {
-	return wait.PollImmediate(time.Second, timeout, isIPPoolAllocationsEmpty(k8sIPAM, ipPoolName))
+func WaitForZeroIPPoolAllocations(k8sIPAM *kubeClient.KubernetesIPAM, ipPoolCIDR string, timeout time.Duration) error {
+	return wait.PollImmediate(time.Second, timeout, isIPPoolAllocationsEmpty(k8sIPAM, ipPoolCIDR))
 }

--- a/pkg/controlloop/entity_generators.go
+++ b/pkg/controlloop/entity_generators.go
@@ -96,14 +96,14 @@ func podNetworkStatusAnnotations(namespace string, networkNames ...string) strin
 	return string(serelizedNetStatus)
 }
 
-func ipPool(ipRange string, namespace string, podReferences ...string) *v1alpha1.IPPool {
+func ipPool(poolIdentifier kubernetes.PoolIdentifier, namespace string, podReferences ...string) *v1alpha1.IPPool {
 	return &v1alpha1.IPPool{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      kubernetes.NormalizeRange(ipRange),
+			Name:      kubernetes.IPPoolName(poolIdentifier),
 			Namespace: namespace,
 		},
 		Spec: v1alpha1.IPPoolSpec{
-			Range:       ipRange,
+			Range:       poolIdentifier.IpRange,
 			Allocations: allocations(podReferences...),
 		},
 	}

--- a/pkg/controlloop/pod.go
+++ b/pkg/controlloop/pod.go
@@ -183,7 +183,7 @@ func (pc *PodController) garbageCollectPodIPs(pod *v1.Pod) error {
 
 		var pools []*whereaboutsv1alpha1.IPPool
 		for _, rangeConfig := range ipamConfig.IPRanges {
-			pool, err := pc.ipPool(rangeConfig.Range)
+			pool, err := pc.ipPool(wbclient.PoolIdentifier{IpRange: rangeConfig.Range, NetworkName: ipamConfig.NetworkName})
 
 			if err != nil {
 				return fmt.Errorf("failed to get the IPPool data: %+v", err)
@@ -271,8 +271,8 @@ func (pc *PodController) ifaceNetAttachDef(ifaceStatus nadv1.NetworkStatus) (*na
 	return nad, nil
 }
 
-func (pc *PodController) ipPool(cidr string) (*whereaboutsv1alpha1.IPPool, error) {
-	pool, err := pc.ipPoolLister.IPPools(ipPoolsNamespace()).Get(wbclient.NormalizeRange(cidr))
+func (pc *PodController) ipPool(poolIdentifier wbclient.PoolIdentifier) (*whereaboutsv1alpha1.IPPool, error) {
+	pool, err := pc.ipPoolLister.IPPools(ipPoolsNamespace()).Get(wbclient.IPPoolName(poolIdentifier))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controlloop/pod_controller_test.go
+++ b/pkg/controlloop/pod_controller_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/api/whereabouts.cni.cncf.io/v1alpha1"
 	wbclient "github.com/k8snetworkplumbingwg/whereabouts/pkg/client/clientset/versioned"
 	fakewbclient "github.com/k8snetworkplumbingwg/whereabouts/pkg/client/clientset/versioned/fake"
+	"github.com/k8snetworkplumbingwg/whereabouts/pkg/storage/kubernetes"
 )
 
 func TestIPControlLoop(t *testing.T) {
@@ -79,7 +80,7 @@ var _ = Describe("IPControlLoop", func() {
 			)
 
 			BeforeEach(func() {
-				dummyNetworkPool = ipPool(dummyNetIPRange, ipPoolsNamespace(), podReference(pod))
+				dummyNetworkPool = ipPool(kubernetes.PoolIdentifier{IpRange: dummyNetIPRange, NetworkName: kubernetes.UnnamedNetwork}, ipPoolsNamespace(), podReference(pod))
 				wbClient = fakewbclient.NewSimpleClientset(dummyNetworkPool)
 			})
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -70,6 +70,7 @@ type IPAMConfig struct {
 	ConfigurationPath        string           `json:"configuration_path"`
 	PodName                  string
 	PodNamespace             string
+	NetworkName              string           `json:"network_name,omitempty"`
 }
 
 func (ic *IPAMConfig) UnmarshalJSON(data []byte) error {
@@ -105,6 +106,7 @@ func (ic *IPAMConfig) UnmarshalJSON(data []byte) error {
 		ConfigurationPath        string           `json:"configuration_path"`
 		PodName                  string
 		PodNamespace             string
+		NetworkName              string           `json:"network_name,omitempty"`
 	}
 
 	ipamConfigAlias := IPAMConfigAlias{
@@ -140,6 +142,7 @@ func (ic *IPAMConfig) UnmarshalJSON(data []byte) error {
 		ConfigurationPath:        ipamConfigAlias.ConfigurationPath,
 		PodName:                  ipamConfigAlias.PodName,
 		PodNamespace:             ipamConfigAlias.PodNamespace,
+		NetworkName:              ipamConfigAlias.NetworkName,
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows specifying an optional `network_name` in the IPAM-config as such:

```json
    {                                                                                                                                                                                                                                          
      "cniVersion": "0.3.1",                                                                                                                                                                                                                   
      "name": "meganet",                                                                                                                                                                                                                       
      "type": "bridge",                                                                                                                                                                                                                        
      "bridge": "meganet",                                                                                                                                                                                                                     
      "ipam": {                                                                                                                                                                                                                                
        "type": "whereabouts",                                                                                                                                                                                                                 
        "range": "10.158.0.1/30",                                                                                                                                                                                                              
        "enable_overlapping_ranges": false,                                                                                                                                                                                                    
        "network_name": "meganet"                                                                                                                                                                                                              
      }                                                                                                                                                                                                                                        
    }                      
```

This allows re-using the same IP range for multiple L2 networks.

This is achieved by creating the `IPPool` resource in kubernetes not as `10.158.0.0-30` but as `meganet-10.158.0.0.30`. When no network-name is given, it defaults to "" and the "-" is left out to enable backwards compatibily.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #50

**Special notes for your reviewer** *(optional)*:
This is only the second time I touch go-code, so if anything seems strange, please do not hesitate to request clarification.
