### PR TITLE
e2e tests: provide cni-install.yml

### DIFF
--- a/hack/cni-install.yml
+++ b/hack/cni-install.yml
@@ -1,0 +1,64 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: cni-install-sh
+  namespace: kube-system
+data:
+  install_cni.sh: |
+    cd /tmp
+    wget https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-amd64-v1.1.1.tgz
+    cd /host/opt/cni/bin
+    tar xvfzp /tmp/cni-plugins-linux-amd64-v1.1.1.tgz
+    sleep infinite
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: install-cni-plugins
+  namespace: kube-system
+  labels:
+    name: cni-plugins
+spec:
+  selector:
+    matchLabels:
+      name: cni-plugins
+  template:
+    metadata:
+      labels:
+        name: cni-plugins
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      containers:
+      - name: install-cni-plugins
+        image: alpine
+        command: ["/bin/sh", "/scripts/install_cni.sh"]
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+          limits:
+            cpu: "100m"
+            memory: "50Mi"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: cni-bin
+          mountPath: /host/opt/cni/bin
+        - name: scripts
+          mountPath: /scripts
+      volumes:
+        - name: cni-bin
+          hostPath:
+            path: /opt/cni/bin
+        - name: scripts
+          configMap:
+            name: cni-install-sh
+            items:
+            - key: install_cni.sh
+              path: install_cni.sh

--- a/hack/e2e-setup-kind-cluster.sh
+++ b/hack/e2e-setup-kind-cluster.sh
@@ -16,7 +16,7 @@ done
 HERE="$(dirname "$(readlink --canonicalize ${BASH_SOURCE[0]})")"
 ROOT="$(readlink --canonicalize "$HERE/..")"
 MULTUS_DAEMONSET_URL="https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/master/deployments/multus-daemonset.yml"
-CNIS_DAEMONSET_URL="https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/master/e2e/cni-install.yml"
+CNIS_DAEMONSET_PATH="$ROOT/hack/cni-install.yml"
 TIMEOUT_K8="5000s"
 RETRY_MAX=10
 INTERVAL=10
@@ -85,7 +85,7 @@ echo "## install multus"
 retry kubectl create -f "${MULTUS_DAEMONSET_URL}"
 retry kubectl -n kube-system wait --for=condition=ready -l name="multus" pod --timeout=$TIMEOUT_K8
 echo "## install CNIs"
-retry kubectl create -f "${CNIS_DAEMONSET_URL}"
+retry kubectl create -f "${CNIS_DAEMONSET_PATH}"
 retry kubectl -n kube-system wait --for=condition=ready -l name="cni-plugins" pod --timeout=$TIMEOUT_K8
 echo "## build whereabouts"
 pushd "$ROOT"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->

**What this PR does / why we need it**:
After the [multus-cni v4 merge](https://github.com/k8snetworkplumbingwg/multus-cni/pull/893) the whereabouts e2e test framework was broken, since
it relies on the cni-install.yml file (previously located in the [multus repo](https://github.com/k8snetworkplumbingwg/multus-cni/blob/f4c0adf54c99d7395d30a050a8d29b674b99d700/e2e/cni-install.yml)) to properly
install the k8s nodes.

By copying the install script to the whereabouts repo, we stop relying on 3rd party repos, and
will no longer be impacted by changes to those foreign repos.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

