### PR TITLE
Install test tools in project-local directory

### DIFF
--- a/hack/generate-code.sh
+++ b/hack/generate-code.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
-controller-gen object crd:crdVersions=v1,trivialVersions=false paths="./..." output:crd:artifacts:config=doc/crds
+BASEDIR=$(pwd)
+${BASEDIR}/bin/controller-gen object crd:crdVersions=v1,trivialVersions=false paths="./..." output:crd:artifacts:config=doc/crds

--- a/hack/install-kubebuilder-tools.sh
+++ b/hack/install-kubebuilder-tools.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 OCI_BIN=${OCI_BIN:-docker}
 
+BASEDIR=$(pwd)
+
 # install controller-gen
-go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1
+GOBIN=${BASEDIR}/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1
 
 # install kubebuilder tools to bin/
 mkdir -p bin

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -8,9 +8,13 @@ GO=${GO:-go}
 echo "Running go vet ..."
 ${GO} vet --tags=test ./cmd/... ./pkg/...
 
+BASEDIR=$(pwd)
+
+echo "Installing golang staticcheck ..."
+GOBIN=${BASEDIR}/bin go install honnef.co/go/tools/cmd/staticcheck@latest
 
 echo "Running golang staticcheck ..."
-staticcheck --tags=test ./...
+${BASEDIR}/bin/staticcheck --tags=test ./...
 
 echo "Running go tests..."
 KUBEBUILDER_ASSETS="$(pwd)/bin" ${GO} test \


### PR DESCRIPTION
# Enhancement

## Motivation

This PR updates the automation scripts to install test tools in project-local bin directory.

Issue is clearly describe in enhancement proposal #267.

## Changes

- Replace the global installation of `controller-gen@0.4.1` with project-local installation in bin directory
- Added script to install `staticcheck` in project-local bin directory before running tests. Also updated the tests to use project-local `staticcheck` installed in bin directory.

## Validation

Automated test runs without any issue using `make test`

## Tasks

### Project management

- [x] Created a related issue
- [x] Added proper labels to the issue @dougbtv 
- [x] Assigned yourself as the assignee @dougbtv 
- [x] Add explanation of changes done

### Code management

- [x] Automated testing of PR
- [x] Checked for mistakenly committed files

Closes #267 