### PR TITLE
build, ci: remove the install-kubebuilder-tools script

### DIFF
--- a/hack/install-kubebuilder-tools.sh
+++ b/hack/install-kubebuilder-tools.sh
@@ -1,19 +1,6 @@
 #!/bin/bash
-OCI_BIN=${OCI_BIN:-docker}
-
 BASEDIR=$(pwd)
 
 # install controller-gen
 GOBIN=${BASEDIR}/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1
-
-# install kubebuilder tools to bin/
-mkdir -p bin
-containerID=$("$OCI_BIN" create gcr.io/kubebuilder/thirdparty-linux:1.16.4)
-"$OCI_BIN" cp ${containerID}:/kubebuilder_linux_amd64.tar.gz ./kubebuilder_linux_amd64.tar.gz
-"$OCI_BIN" rm ${containerID}
-tar -xzvf kubebuilder_linux_amd64.tar.gz
-rm kubebuilder_linux_amd64.tar.gz
-mv kubebuilder/bin/* bin/
-rm -rf kubebuilder/
-chmod +x bin/
 


### PR DESCRIPTION
Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>

<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->

**What this PR does / why we need it**:
In PR #225 we have remove the `controller-runtime` dependencies, and adapted the unit tests to use injected clients that hold the state of the Kubernetes cluster.

As such, we do not need to install the kubebuilder tools in CI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

