### PR TITLE
Fix error thrown by go vet

### DIFF
--- a/pkg/controlloop/pod_controller_test.go
+++ b/pkg/controlloop/pod_controller_test.go
@@ -1,3 +1,6 @@
+//go:build test
+// +build test
+
 package controlloop
 
 import (


### PR DESCRIPTION
# Enhancement

## Motivation

This PR adds _test_ build-tag (`+build test`) in pod_controller_test.go absence of which leads to an error in `go vet`.

Issue is clearly describe in enhancement proposal #279.

## Changes

- Add _test_ build-tag (`+build test`) in `pkg/controlloop/pod_controller_test.go`.

## Validation

Automated test runs without any issue using `make test`

## Tasks

### Project management

- [x] Created a related issue
- [ ] Added proper labels to the issue @dougbtv 
- [ ] Assigned yourself as the assignee @dougbtv 
- [x] Add explanation of changes done

### Code management

- [x] Automated testing of PR
- [x] Checked for mistakenly committed files

Closes #279 