### PR TITLE
Excluded ranges bug

### DIFF
--- a/pkg/allocate/allocate.go
+++ b/pkg/allocate/allocate.go
@@ -221,6 +221,15 @@ func IterateForAssignment(ipnet net.IPNet, rangeStart net.IP, rangeEnd net.IP, r
 		for _, subnet := range excluded {
 			if subnet.Contains(i) {
 				isAddrExcluded = true
+				firstExcluded, _, _ := net.ParseCIDR(subnet.String())
+				_, lastExcluded, _ := GetIPRange(firstExcluded, *subnet)
+				if i.To4() != nil {
+					// exclude broadcast address
+					i = IPAddOffset(lastExcluded, uint64(1))
+				} else {
+					i = lastExcluded
+				}
+				logging.Debugf("excluding %v and moving to the next available ip", subnet)
 			}
 		}
 		if isAddrExcluded {

--- a/pkg/allocate/allocate.go
+++ b/pkg/allocate/allocate.go
@@ -223,13 +223,15 @@ func IterateForAssignment(ipnet net.IPNet, rangeStart net.IP, rangeEnd net.IP, r
 				isAddrExcluded = true
 				firstExcluded, _, _ := net.ParseCIDR(subnet.String())
 				_, lastExcluded, _ := GetIPRange(firstExcluded, *subnet)
-				if i.To4() != nil {
-					// exclude broadcast address
-					i = IPAddOffset(lastExcluded, uint64(1))
-				} else {
-					i = lastExcluded
+				if lastExcluded != nil {
+					if i.To4() != nil {
+						// exclude broadcast address
+						i = IPAddOffset(lastExcluded, uint64(1))
+					} else {
+						i = lastExcluded
+					}
+					logging.Debugf("excluding %v and moving to the next available ip: %v", subnet, i)
 				}
-				logging.Debugf("excluding %v and moving to the next available ip", subnet)
 			}
 		}
 		if isAddrExcluded {

--- a/pkg/allocate/allocate_test.go
+++ b/pkg/allocate/allocate_test.go
@@ -330,6 +330,36 @@ var _ = Describe("Allocation operations", func() {
 		Expect(fmt.Sprint(newip)).To(Equal("100::2:1"))
 	})
 
+	It("can IterateForAssignment on an IPv4 address excluding a range", func() {
+
+		firstip, ipnet, err := net.ParseCIDR("192.168.0.0/29")
+		Expect(err).NotTo(HaveOccurred())
+
+		// figure out the range start.
+		calculatedrangestart := net.ParseIP(firstip.Mask(ipnet.Mask).String())
+
+		var ipres []types.IPReservation
+		exrange := []string{"192.168.0.0/30"}
+		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		Expect(fmt.Sprint(newip)).To(Equal("192.168.0.4"))
+
+	})
+
+	It("can IterateForAssignment on an IPv6 address excluding a range", func() {
+
+		firstip, ipnet, err := net.ParseCIDR("100::2:1/125")
+		Expect(err).NotTo(HaveOccurred())
+
+		// figure out the range start.
+		calculatedrangestart := net.ParseIP(firstip.Mask(ipnet.Mask).String())
+
+		var ipres []types.IPReservation
+		exrange := []string{"100::2:1/126"}
+		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		Expect(fmt.Sprint(newip)).To(Equal("100::2:4"))
+
+	})
+
 	It("creates an IPv6 range properly for 96 bits network address", func() {
 
 		_, ipnet, err := net.ParseCIDR("2001:db8:abcd:0012::0/96")

--- a/pkg/allocate/allocate_test.go
+++ b/pkg/allocate/allocate_test.go
@@ -340,7 +340,7 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		exrange := []string{"192.168.0.0/30"}
-		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		newip, _, _ := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
 		Expect(fmt.Sprint(newip)).To(Equal("192.168.0.4"))
 
 	})
@@ -355,7 +355,7 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		exrange := []string{"100::2:1/126"}
-		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		newip, _, _ := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
 		Expect(fmt.Sprint(newip)).To(Equal("100::2:4"))
 
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->

**What this PR does / why we need it**: You can cause a pod to timeout with a large exclude range, such as this example:

```
apiVersion: k8s.cni.cncf.io/v1                                            
kind: NetworkAttachmentDefinition
metadata:
  name: exclude-problem
spec:
  config: |-
    {
      "cniVersion": "0.3.1",
      "name": "macvlan-net",
      "type": "macvlan",
      "master": "eth0",
      "mode": "bridge",
      "ipam": {
         "type": "whereabouts",
         "range": "f002:f003:f004:0baa::/64",
         "exclude": [ "f002:f003:f004:0baa::/100" ],
         "log_file": "/tmp/whereabouts.log",
         "log_level" : "debug"
      }
```

Thanks @bverschueren for providing the fix!

This pull request also introduces unit tests for related test cases.