### PR TITLE
Fix arm64 image builds in github actions

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -54,3 +54,4 @@ jobs:
           push: false
           tags: ghcr.io/${{ github.repository }}:latest-arm64
           file: Dockerfile.arm64
+          platforms: linux/arm64

--- a/.github/workflows/image-push-master.yml
+++ b/.github/workflows/image-push-master.yml
@@ -1,5 +1,5 @@
 name: Image push for master
-on: 
+on:
   push:
     branches:
       - master
@@ -59,3 +59,4 @@ jobs:
           push: true
           tags: ghcr.io/${{ github.repository }}:latest-ocp
           file: Dockerfile.openshift
+          platforms: linux/arm64

--- a/.github/workflows/image-push-release.yml
+++ b/.github/workflows/image-push-release.yml
@@ -1,5 +1,5 @@
 name: Image push release
-on: 
+on:
   push:
     tags:
       - v*
@@ -75,3 +75,4 @@ jobs:
           tags: |
             ${{ steps.docker_meta.outputs.tags }}-arm64
           file: Dockerfile
+          platforms: linux/arm64


### PR DESCRIPTION
Add the 'platforms' option to arm64 image builds. Otherwise, builds are still in amd64 containers.

<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #254 

**Special notes for your reviewer** *(optional)*:

Looks like VSCode automatically removed some line endings from 2 of the files. Do you care to have me remove those from the PR?
