### PR TITLE
Fix network status annotation to k8s.v1.cni.cncf.io/network-status

### DIFF
--- a/pkg/reconciler/ip_test.go
+++ b/pkg/reconciler/ip_test.go
@@ -443,8 +443,8 @@ func generatePodAnnotations(ipNetworks ...ipInNetwork) map[string]string {
 		networks = append(networks, ipNetworkInfo.networkName)
 	}
 	networkAnnotations := map[string]string{
-		MultusNetworkAnnotation:       strings.Join(networks, ","),
-		MultusNetworkStatusAnnotation: generatePodNetworkStatusAnnotation(ipNetworks...),
+		multusv1.NetworkAttachmentAnnot: strings.Join(networks, ","),
+		multusv1.NetworkStatusAnnot:     generatePodNetworkStatusAnnotation(ipNetworks...),
 	}
 	return networkAnnotations
 }

--- a/pkg/reconciler/wrappedPod.go
+++ b/pkg/reconciler/wrappedPod.go
@@ -10,11 +10,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-const (
-	multusInterfaceNamePrefix = "net"
-	multusPrefixSize          = len(multusInterfaceNamePrefix)
-)
-
 type podWrapper struct {
 	ips   map[string]void
 	phase v1.PodPhase

--- a/pkg/reconciler/wrappedPod.go
+++ b/pkg/reconciler/wrappedPod.go
@@ -11,10 +11,8 @@ import (
 )
 
 const (
-	multusInterfaceNamePrefix     = "net"
-	multusPrefixSize              = len(multusInterfaceNamePrefix)
-	MultusNetworkAnnotation       = "k8s.v1.cni.cncf.io/networks"
-	MultusNetworkStatusAnnotation = "k8s.v1.cni.cncf.io/networks-status"
+	multusInterfaceNamePrefix = "net"
+	multusPrefixSize          = len(multusInterfaceNamePrefix)
 )
 
 type podWrapper struct {
@@ -90,7 +88,7 @@ func getFlatIPSet(pod v1.Pod) (map[string]void, error) {
 }
 
 func networkStatusFromPod(pod v1.Pod) string {
-	networkStatusAnnotationValue, isStatusAnnotationPresent := pod.Annotations[MultusNetworkStatusAnnotation]
+	networkStatusAnnotationValue, isStatusAnnotationPresent := pod.Annotations[k8snetworkplumbingwgv1.NetworkStatusAnnot]
 	if !isStatusAnnotationPresent || len(networkStatusAnnotationValue) == 0 {
 		return "[]"
 	}

--- a/pkg/reconciler/wrappedPod_test.go
+++ b/pkg/reconciler/wrappedPod_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Pod Wrapper operations", func() {
 			annotationString = []byte("")
 		}
 		return map[string]string{
-			MultusNetworkStatusAnnotation: string(annotationString),
+			k8snetworkplumbingwgv1.NetworkStatusAnnot: string(annotationString),
 		}
 	}
 
@@ -60,7 +60,7 @@ var _ = Describe("Pod Wrapper operations", func() {
 			annotationString = []byte("")
 		}
 		return map[string]string{
-			MultusNetworkStatusAnnotation: string(annotationString),
+			k8snetworkplumbingwgv1.NetworkStatusAnnot: string(annotationString),
 		}
 	}
 
@@ -117,7 +117,7 @@ var _ = Describe("Pod Wrapper operations", func() {
 		It("return an empty list when the network annotations of a pod are invalid", func() {
 			pod := v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{MultusNetworkStatusAnnotation: "this-wont-fly"},
+					Annotations: map[string]string{k8snetworkplumbingwgv1.NetworkStatusAnnot: "this-wont-fly"},
 				},
 			}
 			Expect(wrapPod(pod).ips).To(BeEmpty())


### PR DESCRIPTION
Use the correct annotation string k8s.v1.cni.cncf.io/network-status directly from k8snetworkplumbingwg/network-attachment-definition-client

Fixes https://issues.redhat.com/browse/OCPBUGS-10328