### PR TITLE
Bump openshift img builder go1.19

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,5 +1,5 @@
 # This dockerfile is used for building for OpenShift
-FROM registry.ci.openshift.org/openshift/release:golang-1.17 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 ADD . /go/src/github.com/k8snetworkplumbingwg/whereabouts
 WORKDIR /go/src/github.com/k8snetworkplumbingwg/whereabouts
 ENV CGO_ENABLED=1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->

**What this PR does / why we need it**:
This PR aligns the openshift builder images to use the same golang version (1.19) as the other images throughout the repo.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

