### PR TITLE
Improve string representation of Assignment Error

### DIFF
--- a/pkg/allocate/allocate.go
+++ b/pkg/allocate/allocate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"net/netip"
 
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/logging"
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/types"
@@ -16,8 +17,11 @@ type AssignmentError struct {
 	ipnet   net.IPNet
 }
 
+// Error returns the string representation of Assignment Error.
 func (a AssignmentError) Error() string {
-	return fmt.Sprintf("Could not allocate IP in range: ip: %v / - %v / range: %#v", a.firstIP, a.lastIP, a.ipnet)
+	addr, _ := netip.AddrFromSlice(a.ipnet.IP)
+	cidr, _ := a.ipnet.Mask.Size()
+	return fmt.Sprintf("Could not allocate IP in range: network: %s, start: %v, end: %v", netip.PrefixFrom(addr, cidr), a.firstIP, a.lastIP)
 }
 
 // AssignIP assigns an IP using a range and a reserve list.


### PR DESCRIPTION
Requires go 1.18 or higher

<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

Here's the method in the playground:
https://go.dev/play/p/cKqAfUKCasJ?v=goprev

~~~
new format: Could not allocate IP in range: network: 192.168.1.0/24, start: 192.168.1.2, end: 192.168.1.10
old format: Could not allocate IP in range: ip: 192.168.1.2 / - 192.168.1.10 / range: net.IPNet{IP:net.IP{0xc0, 0xa8, 0x1, 0x0}, Mask:net.IPMask{0xff, 0xff, 0xff, 0x0}}
~~~

