### PR TITLE
Provide error when no config was found

### DIFF
--- a/cmd/whereabouts_test.go
+++ b/cmd/whereabouts_test.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -307,7 +308,9 @@ var _ = Describe("Whereabouts operations", func() {
 			Args:        cniArgs(podNamespace, podName),
 		}
 
-		ipamConf, cniVersion, err := config.LoadIPAMConfig([]byte(conf), cniArgs(podNamespace, podName), "")
+		confPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(conf), 0755)).To(Succeed())
+		ipamConf, cniVersion, err := config.LoadIPAMConfig([]byte(conf), cniArgs(podNamespace, podName), confPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipamConf.IPRanges).NotTo(BeEmpty())
 		k8sClient = newK8sIPAM(
@@ -379,7 +382,9 @@ var _ = Describe("Whereabouts operations", func() {
 			Args:        cniArgs(podNamespace, podName),
 		}
 
-		ipamConf, cniVersion, err := config.LoadIPAMConfig([]byte(conf), cniArgs(podNamespace, podName), "")
+		confPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(conf), 0755)).To(Succeed())
+		ipamConf, cniVersion, err := config.LoadIPAMConfig([]byte(conf), cniArgs(podNamespace, podName), confPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipamConf.IPRanges).NotTo(BeEmpty())
 		k8sClient = newK8sIPAM(
@@ -448,7 +453,9 @@ var _ = Describe("Whereabouts operations", func() {
 			Args:        cniArgs(podNamespace, podName),
 		}
 
-		ipamConf, cniVersion, err := config.LoadIPAMConfig([]byte(conf), cniArgs(podNamespace, podName), "")
+		confPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(conf), 0755)).To(Succeed())
+		ipamConf, cniVersion, err := config.LoadIPAMConfig([]byte(conf), cniArgs(podNamespace, podName), confPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipamConf.IPRanges).NotTo(BeEmpty())
 		k8sClient = newK8sIPAM(
@@ -528,7 +535,9 @@ var _ = Describe("Whereabouts operations", func() {
 			Args:        cniArgs(podNamespace, podName),
 		}
 
-		ipamConf, cniVersion, err := config.LoadIPAMConfig([]byte(conf), cniArgs(podNamespace, podName), "")
+		confPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(conf), 0755)).To(Succeed())
+		ipamConf, cniVersion, err := config.LoadIPAMConfig([]byte(conf), cniArgs(podNamespace, podName), confPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipamConf.IPRanges).NotTo(BeEmpty())
 		k8sClient = newK8sIPAM(
@@ -617,7 +626,9 @@ var _ = Describe("Whereabouts operations", func() {
 			Args:        cniArgs(podNamespace, podName),
 		}
 
-		ipamConf, cniVersion, err := config.LoadIPAMConfig([]byte(conf), cniArgs(podNamespace, podName), "")
+		confPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(conf), 0755)).To(Succeed())
+		ipamConf, cniVersion, err := config.LoadIPAMConfig([]byte(conf), cniArgs(podNamespace, podName), confPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipamConf.IPRanges).NotTo(BeEmpty())
 		k8sClient = newK8sIPAM(
@@ -681,7 +692,9 @@ var _ = Describe("Whereabouts operations", func() {
 			Args:        cniArgs(podNamespace, podName),
 		}
 
-		ipamConf, cniVersion, err := config.LoadIPAMConfig([]byte(conf), cniArgs(podNamespace, podName), "")
+		confPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(conf), 0755)).To(Succeed())
+		ipamConf, cniVersion, err := config.LoadIPAMConfig([]byte(conf), cniArgs(podNamespace, podName), confPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipamConf.IPRanges).To(HaveLen(2))
 		k8sClient = newK8sIPAM(
@@ -746,7 +759,9 @@ var _ = Describe("Whereabouts operations", func() {
 			Args:        cniArgs(podNamespace, podName),
 		}
 
-		ipamConf, cniVersion, err := config.LoadIPAMConfig([]byte(conf), cniArgs(podNamespace, podName), "")
+		confPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(conf), 0755)).To(Succeed())
+		ipamConf, cniVersion, err := config.LoadIPAMConfig([]byte(conf), cniArgs(podNamespace, podName), confPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipamConf.IPRanges).To(HaveLen(2))
 		k8sClient = newK8sIPAM(
@@ -809,7 +824,9 @@ var _ = Describe("Whereabouts operations", func() {
 			Args:        cniArgs(podNamespace, podName),
 		}
 
-		ipamConf, cniVersion, err := config.LoadIPAMConfig([]byte(conf), cniArgs(podNamespace, podName), "")
+		confPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(conf), 0755)).To(Succeed())
+		ipamConf, cniVersion, err := config.LoadIPAMConfig([]byte(conf), cniArgs(podNamespace, podName), confPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipamConf.IPRanges).NotTo(BeEmpty())
 		k8sClient = newK8sIPAM(
@@ -875,7 +892,9 @@ var _ = Describe("Whereabouts operations", func() {
 			Args:        cniArgs(podNamespace, podName),
 		}
 
-		ipamConf, cniVersion, err := config.LoadIPAMConfig([]byte(conf), cniArgs(podNamespace, podName), "")
+		confPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(conf), 0755)).To(Succeed())
+		ipamConf, cniVersion, err := config.LoadIPAMConfig([]byte(conf), cniArgs(podNamespace, podName), confPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipamConf.IPRanges).NotTo(BeEmpty())
 		k8sClient = newK8sIPAM(
@@ -934,7 +953,9 @@ var _ = Describe("Whereabouts operations", func() {
 			}
 		  }`, backend)
 
-		ipamConf, cniVersion, err := config.LoadIPAMConfig([]byte(conf), cniArgs(podNamespace, podName), "")
+		confPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(conf), 0755)).To(Succeed())
+		ipamConf, cniVersion, err := config.LoadIPAMConfig([]byte(conf), cniArgs(podNamespace, podName), confPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipamConf.IPRanges).NotTo(BeEmpty())
 		wbClient := *kubernetes.NewKubernetesClient(
@@ -1031,7 +1052,9 @@ var _ = Describe("Whereabouts operations", func() {
 			Args:        cniArgs(podNamespace, podName),
 		}
 
-		ipamConf, cniVersion, err := config.LoadIPAMConfig([]byte(conf), cniArgs(podNamespace, podName), "")
+		confPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(conf), 0755)).To(Succeed())
+		ipamConf, cniVersion, err := config.LoadIPAMConfig([]byte(conf), cniArgs(podNamespace, podName), confPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipamConf.IPRanges).NotTo(BeEmpty())
 		wbClient := *kubernetes.NewKubernetesClient(
@@ -1083,7 +1106,9 @@ var _ = Describe("Whereabouts operations", func() {
 			Args:        cniArgs(podNamespace, podName),
 		}
 
-		secondIPAMConf, secondCNIVersion, err := config.LoadIPAMConfig([]byte(confsecond), cniArgs(podNamespace, podName), "")
+		secondConfPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(confsecond), 0755)).To(Succeed())
+		secondIPAMConf, secondCNIVersion, err := config.LoadIPAMConfig([]byte(confsecond), cniArgs(podNamespace, podName), secondConfPath)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Allocate the IP
@@ -1149,7 +1174,9 @@ var _ = Describe("Whereabouts operations", func() {
 			Args:        cniArgs(podNamespace, podName),
 		}
 
-		ipamConf, cniVersion, err := config.LoadIPAMConfig([]byte(conf), cniArgs(podNamespace, podName), "")
+		confPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(conf), 0755)).To(Succeed())
+		ipamConf, cniVersion, err := config.LoadIPAMConfig([]byte(conf), cniArgs(podNamespace, podName), confPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipamConf.IPRanges).NotTo(BeEmpty())
 		wbClient := *kubernetes.NewKubernetesClient(
@@ -1201,7 +1228,9 @@ var _ = Describe("Whereabouts operations", func() {
 			Args:        cniArgs(podNamespace, podName),
 		}
 
-		secondIPAMConf, secondCNIVersion, err := config.LoadIPAMConfig([]byte(confsecond), cniArgs(podNamespace, podName), "")
+		secondConfPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(confsecond), 0755)).To(Succeed())
+		secondIPAMConf, secondCNIVersion, err := config.LoadIPAMConfig([]byte(confsecond), cniArgs(podNamespace, podName), secondConfPath)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Allocate the IP
@@ -1268,7 +1297,9 @@ var _ = Describe("Whereabouts operations", func() {
 			Args:        cniArgs(podNamespace, podName),
 		}
 
-		ipamConf, cniVersion, err := config.LoadIPAMConfig([]byte(conf), cniArgs(podNamespace, podName), "")
+		confPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(conf), 0755)).To(Succeed())
+		ipamConf, cniVersion, err := config.LoadIPAMConfig([]byte(conf), cniArgs(podNamespace, podName), confPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipamConf.IPRanges).NotTo(BeEmpty())
 		wbClient := *kubernetes.NewKubernetesClient(
@@ -1320,7 +1351,9 @@ var _ = Describe("Whereabouts operations", func() {
 			Args:        cniArgs(podNamespace, podName),
 		}
 
-		secondIPAMConf, secondCNIVersion, err := config.LoadIPAMConfig([]byte(confsecond), cniArgs(podNamespace, podName), "")
+		secondConfPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(secondConfPath, []byte(confsecond), 0755)).To(Succeed())
+		secondIPAMConf, secondCNIVersion, err := config.LoadIPAMConfig([]byte(confsecond), cniArgs(podNamespace, podName), secondConfPath)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Allocate the IP
@@ -1415,10 +1448,26 @@ func ipamConfig(podName string, namespace string, ipRange string, gw string, kub
 		return nil
 	}
 
-	ipamConfWithDefaults, _, err := config.LoadIPAMConfig(bytes, cniArgs(namespace, podName), "")
+	tmpDir, err := os.MkdirTemp("", "whereabouts")
 	if err != nil {
 		return nil
 	}
+	confPath := filepath.Join(tmpDir, "wherebouts.conf")
+	err = os.WriteFile(confPath, bytes, 0755)
+	if err != nil {
+		return nil
+	}
+
+	ipamConfWithDefaults, _, err := config.LoadIPAMConfig(bytes, cniArgs(namespace, podName), confPath)
+	if err != nil {
+		return nil
+	}
+
+	err = os.RemoveAll(tmpDir)
+	if err != nil {
+		return nil
+	}
+
 	return ipamConfWithDefaults
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -256,11 +256,11 @@ func GetFlatIPAM(isControlLoop bool, IPAM *types.IPAMConfig, extraConfigPaths ..
 			}
 
 			foundflatfile = confpath
-			return flatipam, foundflatfile, err
+			return flatipam, foundflatfile, nil
 		}
 	}
-	var err error
-	return flatipam, foundflatfile, err
+
+	return flatipam, foundflatfile, NewConfigFileNotFoundError()
 }
 
 func handleEnvArgs(n *types.Net, numV6 int, numV4 int, args types.IPAMEnvArgs) (int, int, error) {
@@ -368,6 +368,16 @@ func NewInvalidPluginError(ipamType string) *InvalidPluginError {
 
 func (e *InvalidPluginError) Error() string {
 	return fmt.Sprintf("only interested in networks whose IPAM type is 'whereabouts'. This one was: %s", e.ipamType)
+}
+
+type ConfigFileNotFoundError struct{}
+
+func NewConfigFileNotFoundError() *ConfigFileNotFoundError {
+	return &ConfigFileNotFoundError{}
+}
+
+func (e *ConfigFileNotFoundError) Error() string {
+	return "config file not found"
 }
 
 func storageError() error {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -18,6 +19,18 @@ func TestAllocate(t *testing.T) {
 }
 
 var _ = Describe("Allocation operations", func() {
+	var tmpDir string
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "whereabouts")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(tmpDir)).To(Succeed())
+	})
+
 	It("can load a basic config", func() {
 
 		conf := `{
@@ -37,7 +50,10 @@ var _ = Describe("Allocation operations", func() {
         }
       }`
 
-		ipamconfig, _, err := LoadIPAMConfig([]byte(conf), "")
+		confPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(conf), 0755)).To(Succeed())
+
+		ipamconfig, _, err := LoadIPAMConfig([]byte(conf), "", confPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipamconfig.LogLevel).To(Equal("debug"))
 		Expect(ipamconfig.LogFile).To(Equal("/tmp/whereabouts.log"))
@@ -167,7 +183,10 @@ var _ = Describe("Allocation operations", func() {
         ]
     }`
 
-		ipamconfig, err := LoadIPAMConfiguration([]byte(conf), "")
+		confPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(conf), 0755)).To(Succeed())
+
+		ipamconfig, err := LoadIPAMConfiguration([]byte(conf), "", confPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipamconfig.LogLevel).To(Equal("debug"))
 		Expect(ipamconfig.LogFile).To(Equal("/tmp/whereabouts.log"))
@@ -214,7 +233,10 @@ var _ = Describe("Allocation operations", func() {
         }
       }`
 
-		ipamConfig, _, err := LoadIPAMConfig([]byte(conf), "")
+		confPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(conf), 0755)).To(Succeed())
+
+		ipamConfig, _, err := LoadIPAMConfig([]byte(conf), "", confPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipamConfig.IPRanges[0].Range).To(Equal("192.168.1.0/24"))
 		Expect(ipamConfig.IPRanges[0].RangeStart).To(Equal(net.ParseIP("192.168.1.5")))
@@ -239,7 +261,10 @@ var _ = Describe("Allocation operations", func() {
         }
       }`
 
-		ipamConfig, _, err := LoadIPAMConfig([]byte(conf), "")
+		confPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(conf), 0755)).To(Succeed())
+
+		ipamConfig, _, err := LoadIPAMConfig([]byte(conf), "", confPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipamConfig.IPRanges[0].Range).To(Equal("192.168.1.0/24"))
 		Expect(ipamConfig.IPRanges[0].RangeStart).To(Equal(net.ParseIP("192.168.1.0")))
@@ -264,7 +289,10 @@ var _ = Describe("Allocation operations", func() {
         }
       }`
 
-		ipamConfig, _, err := LoadIPAMConfig([]byte(conf), "")
+		confPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(conf), 0755)).To(Succeed())
+
+		ipamConfig, _, err := LoadIPAMConfig([]byte(conf), "", confPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipamConfig.IPRanges[0].Range).To(Equal("192.168.1.0/24"))
 		Expect(ipamConfig.IPRanges[0].RangeStart).To(Equal(net.ParseIP("192.168.1.44")))
@@ -290,7 +318,10 @@ var _ = Describe("Allocation operations", func() {
         }
       }`
 
-		ipamConfig, _, err := LoadIPAMConfig([]byte(conf), "")
+		confPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(conf), 0755)).To(Succeed())
+
+		ipamConfig, _, err := LoadIPAMConfig([]byte(conf), "", confPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipamConfig.IPRanges[0].Range).To(Equal("192.168.1.0/24"))
 		Expect(ipamConfig.IPRanges[0].RangeStart).To(Equal(net.ParseIP("192.168.1.44")))
@@ -318,7 +349,10 @@ var _ = Describe("Allocation operations", func() {
         }
       }`
 
-		ipamConfig, _, err := LoadIPAMConfig([]byte(conf), "")
+		confPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(conf), 0755)).To(Succeed())
+
+		ipamConfig, _, err := LoadIPAMConfig([]byte(conf), "", confPath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ipamConfig.IPRanges[0].Range).To(Equal("192.168.1.0/24"))
 		Expect(ipamConfig.IPRanges[0].RangeStart).To(Equal(net.ParseIP("192.168.1.44")))
@@ -340,7 +374,11 @@ var _ = Describe("Allocation operations", func() {
 				"gateway": "192.168.10.1"
 			}
 		}`
-		_, _, err := LoadIPAMConfig([]byte(invalidConf), "")
+
+		confPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(invalidConf), 0755)).To(Succeed())
+
+		_, _, err := LoadIPAMConfig([]byte(invalidConf), "", confPath)
 		Expect(err).To(MatchError("invalid range start for CIDR 192.168.2.16/28: 192.168.1.5"))
 	})
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -8,6 +8,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/k8snetworkplumbingwg/whereabouts/pkg/types"
 )
 
 func TestAllocate(t *testing.T) {
@@ -47,6 +49,11 @@ var _ = Describe("Allocation operations", func() {
 		Expect(ipamconfig.LeaderRenewDeadline).To(Equal(1000))
 		Expect(ipamconfig.LeaderRetryPeriod).To(Equal(500))
 
+	})
+
+	It("throws an error when no flat-files are found", func() {
+		_, _, err := GetFlatIPAM(true, &types.IPAMConfig{})
+		Expect(err).To(MatchError(NewConfigFileNotFoundError()))
 	})
 
 	It("can load a global flat-file config", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
The control loop currently segfaults when none of the config files was found. This commit makes it give an actual error, providing the user with useful feedback.

**Which issue(s) this PR fixes** 
If needed, I'll raise an issue, please let me know.

**Special notes for your reviewer** *(optional)*:

