### PR TITLE
fix 'latest-arm' image to build for arm64, not amd64

### DIFF
--- a/.github/workflows/image-push-master.yml
+++ b/.github/workflows/image-push-master.yml
@@ -88,3 +88,4 @@ jobs:
           push: true
           tags: ghcr.io/${{ github.repository }}:latest-arm64
           file: Dockerfile.arm64
+          platforms: linux/arm64


### PR DESCRIPTION
The build-push action for master 'latest-arm64' images were being done for amd64 incorrectly. Fix this.

<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

