### PR TITLE
build & use multi-arch manifests for doc/crds

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -58,3 +58,25 @@ jobs:
           tags: ghcr.io/${{ github.repository }}:latest-arm64
           file: Dockerfile.arm64
           platforms: linux/arm64
+
+  build-multi-arch:
+    name: Image build multi-arch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build container image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: false
+          tags: ghcr.io/${{ github.repository }}:latest
+          file: Dockerfile
+          platforms: linux/amd64, linux/arm64

--- a/.github/workflows/image-push-master.yml
+++ b/.github/workflows/image-push-master.yml
@@ -89,3 +89,33 @@ jobs:
           tags: ghcr.io/${{ github.repository }}:latest-arm64
           file: Dockerfile.arm64
           platforms: linux/arm64
+
+  push-multi-arch:
+    name: Image build multi-arch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Container Registry
+        if: github.repository_owner == 'k8snetworkplumbingwg'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build container image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest
+          file: Dockerfile
+          platforms: linux/amd64, linux/arm64

--- a/.github/workflows/image-push-release.yml
+++ b/.github/workflows/image-push-release.yml
@@ -79,3 +79,42 @@ jobs:
             ${{ steps.docker_meta.outputs.tags }}-arm64
           file: Dockerfile
           platforms: linux/arm64
+
+  push-multi-arch:
+    name: Image push multi-arch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Container Registry
+        if: github.repository_owner == 'k8snetworkplumbingwg'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tag-latest: false
+
+      - name: Push container image
+        if: github.repository_owner == 'k8snetworkplumbingwg'
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          file: Dockerfile
+          platforms: linux/amd64, linux/arm64

--- a/doc/crds/daemonset-install.yaml
+++ b/doc/crds/daemonset-install.yaml
@@ -91,10 +91,8 @@ spec:
         app: whereabouts
         name: whereabouts
     spec:
-      hostNetwork: true      
+      hostNetwork: true
       serviceAccountName: whereabouts
-      nodeSelector:
-        kubernetes.io/arch: amd64
       tolerations:
       - operator: Exists
         effect: NoSchedule
@@ -106,7 +104,7 @@ spec:
           - >
             SLEEP=false /install-cni.sh &&
             /ip-control-loop -log-level debug
-        image: ghcr.io/k8snetworkplumbingwg/whereabouts:latest-amd64
+        image: ghcr.io/k8snetworkplumbingwg/whereabouts:latest
         env:
         - name: NODENAME
           valueFrom:


### PR DESCRIPTION
Build multi-arch manifests (amd64 and arm64) for PR 'build`, 'master' images, and 'release' images. In the doc/crds/daemonset-install.yaml file, remove amd64-specific items, and use the 'latest' manifest that will autoselect the appropriate architecture for the system.

Starting as a draft PR to make sure the build test passes and to make sure to start from a place of discussion. This PR is more about convenience than necessity for me.

<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->

**What this PR does / why we need it**:
Allow deploying one version of the sample deployment for any (x86/arm) architecture. This simplifies deployment for users. This is a matter of convenience rather than necessity. Even users who have mixed amd64/arm64 environments can create 2 daemonsets for whereabouts -- one with the current selector for x86 and one with a modified selector for arm.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

