### PR TITLE
Denormalize IP name before checking if pod is alive

### DIFF
--- a/pkg/reconciler/ip_test.go
+++ b/pkg/reconciler/ip_test.go
@@ -304,6 +304,7 @@ var _ = Describe("Whereabouts IP reconciler", func() {
 			clusterWideIPAllocations, err := wbClient.WhereaboutsV1alpha1().OverlappingRangeIPReservations(namespace).List(context.TODO(), metav1.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(clusterWideIPAllocations.Items).To(HaveLen(expectedClusterWideIPs))
+			Expect(k8sClientSet.CoreV1().Pods(namespace).Delete(context.TODO(), pods[0].Name, metav1.DeleteOptions{})).NotTo(HaveOccurred())
 		})
 	})
 

--- a/pkg/reconciler/iploop.go
+++ b/pkg/reconciler/iploop.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -164,9 +165,12 @@ func (rl *ReconcileLooper) findClusterWideIPReservations(ctx context.Context) er
 
 	for _, clusterWideIPReservation := range clusterWideIPReservations {
 		ip := clusterWideIPReservation.GetName()
+		// De-normalize the IP
+		denormalizedip := strings.ReplaceAll(ip, "-", ":")
+
 		podRef := clusterWideIPReservation.Spec.PodRef
 
-		if !rl.isPodAlive(podRef, ip) {
+		if !rl.isPodAlive(podRef, denormalizedip) {
 			logging.Debugf("pod ref %s is not listed in the live pods list", podRef)
 			rl.orphanedClusterWideIPs = append(rl.orphanedClusterWideIPs, clusterWideIPReservation)
 		}

--- a/pkg/reconciler/iploop.go
+++ b/pkg/reconciler/iploop.go
@@ -166,6 +166,8 @@ func (rl *ReconcileLooper) findClusterWideIPReservations(ctx context.Context) er
 	for _, clusterWideIPReservation := range clusterWideIPReservations {
 		ip := clusterWideIPReservation.GetName()
 		// De-normalize the IP
+		// In the UpdateOverlappingRangeAllocation function, the IP address is created with a "normalized" name to comply with the k8s api.
+		// We must denormalize here in order to properly look up the IP address in the regular format, which pods use.
 		denormalizedip := strings.ReplaceAll(ip, "-", ":")
 
 		podRef := clusterWideIPReservation.Spec.PodRef


### PR DESCRIPTION
This commit solves the issue of normalized IP names being used for checking if a pod is alive, which resulted in overlappingrangeipreservations being falsely deleted by the ip-reconciler.