### PR TITLE
logging: use the RFC3399Nano timestamp format

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -40,7 +40,7 @@ var loggingStderr bool
 var loggingFp *os.File
 var loggingLevel Level
 
-const defaultTimestampFormat = time.RFC3339
+const defaultTimestampFormat = time.RFC3339Nano
 
 func (l Level) String() string {
 	switch l {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->

**What this PR does / why we need it**:
The old format - RFC3339 - does not have enough precision - we need to see milliseconds (at least) to understand how long does it take for a CNI ADD / DEL to be processed in the IPAM stage to understand how long does it take for a CNI ADD / DEL to be processed in the IPAM stage.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:
Old format:
> 2023-08-17T10:13:19Z [debug] Beginning IPAM for ContainerID: 5c4a2a24ef14b4c35fd55f553ffb7fcb6c05e493f2ba2f6d108b61cdf969cc86
2023-08-17T10:13:19Z [debug] Started leader election
2023-08-17T10:13:19Z [debug] OnStartedLeading() called
2023-08-17T10:13:19Z [debug] Elected as leader, do processing


New format: 
> 2023-08-17T12:57:03.831205669Z [debug] OnStoppedLeading() called
2023-08-17T12:57:03.831217323Z [debug] Finished leader election
2023-08-17T12:57:03.831225863Z [debug] IPManagement: [{<nil> <nil>}], <nil>

