### PR TITLE
Extended support for customizing whereabouts ip-reconciler cron schedule

### DIFF
--- a/doc/crds/daemonset-install.yaml
+++ b/doc/crds/daemonset-install.yaml
@@ -70,6 +70,19 @@ rules:
   - patch
   - update
   - get
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cron-scheduler-configmap
+  namespace: kube-system
+  annotations:
+    kubernetes.io/description: |
+      Configmap containing user customizable cronjob schedule
+data:
+  reconciler_cron_file: "30 4 * * *" # Default schedule is once per day at 4:30am. Users may configure this value to their liking.
+
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -130,6 +143,8 @@ spec:
           mountPath: /host/opt/cni/bin
         - name: cni-net-dir
           mountPath: /host/etc/cni/net.d
+        - name: cron-scheduler-configmap
+            mountPath: /cron-schedule
       volumes:
         - name: cnibin
           hostPath:
@@ -137,3 +152,7 @@ spec:
         - name: cni-net-dir
           hostPath:
             path: /etc/cni/net.d
+        - name: cron-scheduler-configmap
+          configMap:
+            name: "cron-scheduler-configmap"
+            defaultMode: 0744

--- a/doc/extended-configuration.md
+++ b/doc/extended-configuration.md
@@ -134,9 +134,13 @@ spec:
 
 You'll note that in the `ipam` section there's a lot less parameters than are used in the previous examples.
 
-### Reconciler Cron Expression Configuration (optional)
+## Reconciler Cron Expression configuration for clusters via flatfile (optional)
 
-You may want to provide a cron expression to configure how frequently the ip-reconciler runs. This is done via the flatfile.
+*NOTE: configuring cron expression prior to cluster launch will only work for **non-Openshift** Kubernetes clusters, such as a vanilla Kubernetes cluster. Skip to the next section if you have an Openshift cluster or a cluster that has already launched.*
+
+Yuki~ do we even need to support configuring via flatfile? Leaving it for now, but hey, food for thought.
+
+You may want to provide a cron expression to configure how frequently the ip-reconciler runs. For clusters that have not yet been launched, this can be configured via the flatfile.
 
 You can speficy the `WHEREABOUTS_RECONCILER_CRON` environment variable in your daemonset definition file to override the default cron expression:
 ```yaml
@@ -144,6 +148,19 @@ You can speficy the `WHEREABOUTS_RECONCILER_CRON` environment variable in your d
         - name: WHEREABOUTS_RECONCILER_CRON
           value: 30 * * * *
 ```
+
+## Reconciler Cron Expression Configuration for live clusters via configmap (optional)
+
+Yuki~ README: this section may belong in the CNO since the steps outlined are not technically part of whereabouts. I'm not sure, and suggestions are welcome.
+
+You may want to provide a cron expression to configure how frequently the ip-reconciler runs. For **Openshift** Kubernetes clusters, this is done via updating the cron-scheduler-configmap. 
+
+You can check that the cron-scheduler-configmap is present by running `oc get configmaps` in the openshift-multus namespace.
+
+To update the cron-scheduler-configmap, run `oc edit configmap cron-scheduler-configmap` and adjust the value to a valid cron expression of your liking. Shortly after, the reconciler schedule will update.
+
+If you are using a non-Openshift cluster, you can do the same steps, but you will need to look for the configmap in the kube-system namespace.
+
 ## Installing etcd. (optional)
 
 etcd installation is optional. By default, we recommend the custom resource backend (given in the first example configuration).

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -70,7 +70,7 @@ type IPAMConfig struct {
 	ConfigurationPath        string           `json:"configuration_path"`
 	PodName                  string
 	PodNamespace             string
-	NetworkName              string           `json:"network_name,omitempty"`
+	NetworkName              string `json:"network_name,omitempty"`
 }
 
 func (ic *IPAMConfig) UnmarshalJSON(data []byte) error {
@@ -106,7 +106,7 @@ func (ic *IPAMConfig) UnmarshalJSON(data []byte) error {
 		ConfigurationPath        string           `json:"configuration_path"`
 		PodName                  string
 		PodNamespace             string
-		NetworkName              string           `json:"network_name,omitempty"`
+		NetworkName              string `json:"network_name,omitempty"`
 	}
 
 	ipamConfigAlias := IPAMConfigAlias{

--- a/script/install-cni.sh
+++ b/script/install-cni.sh
@@ -19,7 +19,7 @@ WHEREABOUTS_RECONCILER_CRON=${WHEREABOUTS_RECONCILER_CRON:-30 4 * * *}
 
 mkdir -p $CNI_CONF_DIR/whereabouts.d
 WHEREABOUTS_KUBECONFIG=$CNI_CONF_DIR/whereabouts.d/whereabouts.kubeconfig
-WHEREABOUTS_FLATFILE=$CNI_CONF_DIR/whereabouts.d/whereabouts.conf
+WHEREABOUTS_FLATFILE=$CNI_CONF_DIR/whereabouts.d/whereabouts.conf # Yuki~ Nikhil's note: imo we should remove "flatfile" from whereabouts vocabulary and call this "WHEREABOUTS_CONF_FILE" instead. Flatfile may be the format but it's confusing naming.
 WHEREABOUTS_KUBECONFIG_LITERAL=$(echo "$WHEREABOUTS_KUBECONFIG" | sed -e s'|/host||')
 
 # ------------------------------- Generate a "kube-config"


### PR DESCRIPTION
Added a configmap with "cron_schedule" key value pair. The value of cron_schedule (i.e. "30 4 * * *") will be put into a file of the same name on whereabouts ip-reconciler pods, such that when the reconciler is enabled, the file should appear on the pod.

Whereabouts will now search for the reconciler_cron_file, and if present, it will use the cron schedule from the file. If the file is not present a default value from the flatfile will be used instead.
