### PR TITLE
Rebases #180: ip-reconciler: Use ContainerID instead of PodRef

### DIFF
--- a/pkg/reconciler/iploop.go
+++ b/pkg/reconciler/iploop.go
@@ -177,7 +177,6 @@ func composePodRef(pod v1.Pod) string {
 func (rl ReconcileLooper) ReconcileIPPools(ctx context.Context) ([]net.IP, error) {
 	matchByContainerID := func(reservations []types.IPReservation, containerID string) int {
 		foundidx := -1
-		fmt.Printf("!bang ------------- %+v", reservations)
 		for idx, v := range reservations {
 			if v.ContainerID == containerID {
 				return idx

--- a/pkg/reconciler/iploop.go
+++ b/pkg/reconciler/iploop.go
@@ -189,10 +189,12 @@ func (rl ReconcileLooper) ReconcileIPPools(ctx context.Context) ([]net.IP, error
 	var err error
 	var totalCleanedUpIps []net.IP
 	for _, orphanedIP := range rl.orphanedIPs {
+		// !bang: Reportedly: This the order returned from the below line is not fixed.
 		currentIPReservations := orphanedIP.Pool.Allocations()
 		containerIDsToDeallocate := findOutContainerIDsToDeallocateIPsFrom(orphanedIP)
 		var deallocatedIP net.IP
 		for _, containerID := range containerIDsToDeallocate {
+			// !bang: This means it may cause the in-use pod ip to be wrongly claimed
 			currentIPReservations, deallocatedIP, err = allocate.IterateForDeallocation(currentIPReservations, containerID, matchByContainerID)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
This is a (somewhat manual) rebase of #180 -- 

It looks like it's working in my testing of it, but... I initially had some **incorrect keys deleted only  sometimes**  when I was first testing it, and getting the wrong IPs deleted? 

So I was getting failures like:

```
Whereabouts IP reconciler
/home/doug/codebase/src/github.com/dougbtv/whereabouts/pkg/reconciler/ip_test.go:34
  reconciling an IP pool with multiple pods attached
  /home/doug/codebase/src/github.com/dougbtv/whereabouts/pkg/reconciler/ip_test.go:98
    each with IP from the same IPPool
    /home/doug/codebase/src/github.com/dougbtv/whereabouts/pkg/reconciler/ip_test.go:122
      reconciling the IPPool
      /home/doug/codebase/src/github.com/dougbtv/whereabouts/pkg/reconciler/ip_test.go:139
        should report the dead pod's IP address as deleted [It]
        /home/doug/codebase/src/github.com/dougbtv/whereabouts/pkg/reconciler/ip_test.go:146

        Expected
            <[]net.IP | len:1, cap:1>: [
                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 10, 10, 10, 2],
            ]
        to equal
            <[]net.IP | len:1, cap:1>: [
                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 10, 10, 10, 1],
            ]

        /home/doug/codebase/src/github.com/dougbtv/whereabouts/pkg/reconciler/ip_test.go:150
```

However, with whatever finagling I was doing, those have gone away... Or so I think.

So I've been testing it in a loop to repeat it a bunch of times, like:

```bash
#!/bin/bash

for i in {1..20}; do
    echo "Running test-go.sh - Attempt $i"
    ./hack/test-go.sh > /tmp/test_output_$i.txt 2>&1
    if [ $? -ne 0 ]; then
        echo "Test failed on attempt $i, output saved to /tmp/test_output_$i.txt"
    else
        rm /tmp/test_output_$i.txt
        echo "Test passed on attempt $i"
    fi
done
```