### PR TITLE
api: re-gen files to humor verify-codegen stages

### DIFF
--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors
+Copyright 2024 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/client/clientset/versioned/doc.go
+++ b/pkg/client/clientset/versioned/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors
+Copyright 2024 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors
+Copyright 2024 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/client/clientset/versioned/fake/doc.go
+++ b/pkg/client/clientset/versioned/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors
+Copyright 2024 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors
+Copyright 2024 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/client/clientset/versioned/scheme/doc.go
+++ b/pkg/client/clientset/versioned/scheme/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors
+Copyright 2024 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors
+Copyright 2024 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/client/clientset/versioned/typed/whereabouts.cni.cncf.io/v1alpha1/doc.go
+++ b/pkg/client/clientset/versioned/typed/whereabouts.cni.cncf.io/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors
+Copyright 2024 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/client/clientset/versioned/typed/whereabouts.cni.cncf.io/v1alpha1/fake/doc.go
+++ b/pkg/client/clientset/versioned/typed/whereabouts.cni.cncf.io/v1alpha1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors
+Copyright 2024 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/client/clientset/versioned/typed/whereabouts.cni.cncf.io/v1alpha1/fake/fake_ippool.go
+++ b/pkg/client/clientset/versioned/typed/whereabouts.cni.cncf.io/v1alpha1/fake/fake_ippool.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors
+Copyright 2024 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/client/clientset/versioned/typed/whereabouts.cni.cncf.io/v1alpha1/fake/fake_overlappingrangeipreservation.go
+++ b/pkg/client/clientset/versioned/typed/whereabouts.cni.cncf.io/v1alpha1/fake/fake_overlappingrangeipreservation.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors
+Copyright 2024 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/client/clientset/versioned/typed/whereabouts.cni.cncf.io/v1alpha1/fake/fake_whereabouts.cni.cncf.io_client.go
+++ b/pkg/client/clientset/versioned/typed/whereabouts.cni.cncf.io/v1alpha1/fake/fake_whereabouts.cni.cncf.io_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors
+Copyright 2024 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/client/clientset/versioned/typed/whereabouts.cni.cncf.io/v1alpha1/generated_expansion.go
+++ b/pkg/client/clientset/versioned/typed/whereabouts.cni.cncf.io/v1alpha1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors
+Copyright 2024 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/client/clientset/versioned/typed/whereabouts.cni.cncf.io/v1alpha1/ippool.go
+++ b/pkg/client/clientset/versioned/typed/whereabouts.cni.cncf.io/v1alpha1/ippool.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors
+Copyright 2024 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/client/clientset/versioned/typed/whereabouts.cni.cncf.io/v1alpha1/overlappingrangeipreservation.go
+++ b/pkg/client/clientset/versioned/typed/whereabouts.cni.cncf.io/v1alpha1/overlappingrangeipreservation.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors
+Copyright 2024 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/client/clientset/versioned/typed/whereabouts.cni.cncf.io/v1alpha1/whereabouts.cni.cncf.io_client.go
+++ b/pkg/client/clientset/versioned/typed/whereabouts.cni.cncf.io/v1alpha1/whereabouts.cni.cncf.io_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors
+Copyright 2024 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors
+Copyright 2024 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors
+Copyright 2024 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors
+Copyright 2024 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/client/informers/externalversions/whereabouts.cni.cncf.io/interface.go
+++ b/pkg/client/informers/externalversions/whereabouts.cni.cncf.io/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors
+Copyright 2024 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/client/informers/externalversions/whereabouts.cni.cncf.io/v1alpha1/interface.go
+++ b/pkg/client/informers/externalversions/whereabouts.cni.cncf.io/v1alpha1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors
+Copyright 2024 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/client/informers/externalversions/whereabouts.cni.cncf.io/v1alpha1/ippool.go
+++ b/pkg/client/informers/externalversions/whereabouts.cni.cncf.io/v1alpha1/ippool.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors
+Copyright 2024 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/client/informers/externalversions/whereabouts.cni.cncf.io/v1alpha1/overlappingrangeipreservation.go
+++ b/pkg/client/informers/externalversions/whereabouts.cni.cncf.io/v1alpha1/overlappingrangeipreservation.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors
+Copyright 2024 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/client/listers/whereabouts.cni.cncf.io/v1alpha1/expansion_generated.go
+++ b/pkg/client/listers/whereabouts.cni.cncf.io/v1alpha1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors
+Copyright 2024 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/client/listers/whereabouts.cni.cncf.io/v1alpha1/ippool.go
+++ b/pkg/client/listers/whereabouts.cni.cncf.io/v1alpha1/ippool.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors
+Copyright 2024 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/client/listers/whereabouts.cni.cncf.io/v1alpha1/overlappingrangeipreservation.go
+++ b/pkg/client/listers/whereabouts.cni.cncf.io/v1alpha1/overlappingrangeipreservation.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors
+Copyright 2024 The Kubernetes Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->

**What this PR does / why we need it**:
This PR updates the Whereabouts client generated code's license header to feature the new year; the lint target would fail otherwise, since the newly generated files != from the repo committed ones.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:
This PR will prevent https://github.com/k8snetworkplumbingwg/whereabouts/actions/runs/7447878968/job/20261047088 from happening, and allow CI to greenlight merges.

