### PR TITLE
Use newer contianernetworking/cni 100 type

### DIFF
--- a/cmd/whereabouts.go
+++ b/cmd/whereabouts.go
@@ -8,10 +8,9 @@ import (
 
 	"github.com/containernetworking/cni/pkg/skel"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
-	current "github.com/containernetworking/cni/pkg/types/040"
+	current "github.com/containernetworking/cni/pkg/types/100"
 	cniversion "github.com/containernetworking/cni/pkg/version"
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/config"
-	"github.com/k8snetworkplumbingwg/whereabouts/pkg/iphelpers"
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/logging"
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/storage/kubernetes"
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/types"
@@ -83,17 +82,8 @@ func cmdAdd(args *skel.CmdArgs, client *kubernetes.KubernetesIPAM, cniVersion st
 		return fmt.Errorf("error at storage engine: %w", err)
 	}
 
-	var useVersion string
 	for _, newip := range newips {
-		// Determine if v4 or v6.
-		if iphelpers.IsIPv4(newip.IP) {
-			useVersion = "4"
-		} else {
-			useVersion = "6"
-		}
-
 		result.IPs = append(result.IPs, &current.IPConfig{
-			Version: useVersion,
 			Address: newip,
 			Gateway: client.Config.Gateway})
 	}
@@ -101,7 +91,6 @@ func cmdAdd(args *skel.CmdArgs, client *kubernetes.KubernetesIPAM, cniVersion st
 	// Assign all the static IP elements.
 	for _, v := range client.Config.Addresses {
 		result.IPs = append(result.IPs, &current.IPConfig{
-			Version: v.Version,
 			Address: v.Address,
 			Gateway: v.Gateway})
 	}

--- a/cmd/whereabouts_test.go
+++ b/cmd/whereabouts_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
-	current "github.com/containernetworking/cni/pkg/types/040"
+	current "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/plugins/pkg/testutils"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -84,7 +84,6 @@ func AllocateAndReleaseAddressesTest(ipVersion string, ipamConf *whereaboutstype
 		// Gomega is cranky about slices with different caps
 		ExpectWithOffset(1, *result.IPs[0]).To(Equal(
 			current.IPConfig{
-				Version: ipVersion,
 				Address: mustCIDR(expectedAddresses[i]),
 				Gateway: ipamConf.Gateway,
 			}))
@@ -107,7 +106,6 @@ func AllocateAndReleaseAddressesTest(ipVersion string, ipamConf *whereaboutstype
 
 		Expect(*result.IPs[0]).To(Equal(
 			current.IPConfig{
-				Version: ipVersion,
 				Address: mustCIDR(expectedAddresses[i]),
 				Gateway: ipamConf.Gateway,
 			}))
@@ -333,7 +331,6 @@ var _ = Describe("Whereabouts operations", func() {
 		// Gomega is cranky about slices with different caps
 		Expect(*result.IPs[0]).To(Equal(
 			current.IPConfig{
-				Version: "4",
 				Address: mustCIDR("192.168.1.32/24"),
 				Gateway: net.ParseIP("192.168.10.1"),
 			}))
@@ -407,7 +404,6 @@ var _ = Describe("Whereabouts operations", func() {
 		// Gomega is cranky about slices with different caps
 		Expect(*result.IPs[0]).To(Equal(
 			current.IPConfig{
-				Version: "6",
 				Address: mustCIDR("2001::3/116"),
 				Gateway: net.ParseIP("2001::f:1"),
 			}))
@@ -478,7 +474,6 @@ var _ = Describe("Whereabouts operations", func() {
 		// Gomega is cranky about slices with different caps
 		Expect(*result.IPs[0]).To(Equal(
 			current.IPConfig{
-				Version: "6",
 				Address: mustCIDR("caa5::8000/112"),
 				Gateway: net.ParseIP("2001::f:1"),
 			}))
@@ -561,21 +556,18 @@ var _ = Describe("Whereabouts operations", func() {
 
 		Expect(*result.IPs[0]).To(Equal(
 			current.IPConfig{
-				Version: "4",
 				Address: mustCIDR("192.168.1.33/28"),
 				Gateway: net.ParseIP("192.168.1.1"),
 			}))
 
 		Expect(*result.IPs[1]).To(Equal(
 			current.IPConfig{
-				Version: "4",
 				Address: mustCIDR("10.10.0.1/24"),
 				Gateway: net.ParseIP("10.10.0.254"),
 			}))
 
 		Expect(*result.IPs[2]).To(Equal(
 			current.IPConfig{
-				Version: "6",
 				Address: mustCIDR("3ffe:ffff:0:01ff::1/64"),
 				Gateway: net.ParseIP("3ffe:ffff:0::1"),
 			},
@@ -850,7 +842,6 @@ var _ = Describe("Whereabouts operations", func() {
 
 		Expect(*result.IPs[0]).To(Equal(
 			current.IPConfig{
-				Version: "4",
 				Address: mustCIDR("192.168.1.5/24"),
 				Gateway: net.ParseIP("192.168.10.1"),
 			}))
@@ -918,7 +909,6 @@ var _ = Describe("Whereabouts operations", func() {
 
 		Expect(*result.IPs[0]).To(Equal(
 			current.IPConfig{
-				Version: "4",
 				Address: mustCIDR("192.168.1.5/24"),
 				Gateway: net.ParseIP("192.168.10.1"),
 			}))
@@ -987,7 +977,6 @@ var _ = Describe("Whereabouts operations", func() {
 
 			Expect(*result.IPs[0]).To(Equal(
 				current.IPConfig{
-					Version: "4",
 					Address: mustCIDR(fmt.Sprintf("192.168.1.%d/24", 5+i)),
 					Gateway: net.ParseIP("192.168.10.1"),
 				}))
@@ -1076,7 +1065,6 @@ var _ = Describe("Whereabouts operations", func() {
 		// Gomega is cranky about slices with different caps
 		ExpectWithOffset(1, *result.IPs[0]).To(Equal(
 			current.IPConfig{
-				Version: "4",
 				Address: mustCIDR("192.168.22.1/24"),
 			}))
 
@@ -1124,7 +1112,6 @@ var _ = Describe("Whereabouts operations", func() {
 		// Gomega is cranky about slices with different caps
 		ExpectWithOffset(1, *result.IPs[0]).To(Equal(
 			current.IPConfig{
-				Version: "4",
 				Address: mustCIDR("192.168.22.2/28"),
 			}))
 
@@ -1198,7 +1185,6 @@ var _ = Describe("Whereabouts operations", func() {
 		// Gomega is cranky about slices with different caps
 		ExpectWithOffset(1, *result.IPs[0]).To(Equal(
 			current.IPConfig{
-				Version: "6",
 				Address: mustCIDR("2001::2:3:1/124"),
 			}))
 
@@ -1246,7 +1232,6 @@ var _ = Describe("Whereabouts operations", func() {
 		// Gomega is cranky about slices with different caps
 		ExpectWithOffset(1, *result.IPs[0]).To(Equal(
 			current.IPConfig{
-				Version: "6",
 				Address: mustCIDR("2001::2:3:2/126"),
 			}))
 
@@ -1321,7 +1306,6 @@ var _ = Describe("Whereabouts operations", func() {
 		// Gomega is cranky about slices with different caps
 		ExpectWithOffset(1, *result.IPs[0]).To(Equal(
 			current.IPConfig{
-				Version: "4",
 				Address: mustCIDR("192.168.33.1/24"),
 			}))
 
@@ -1369,7 +1353,6 @@ var _ = Describe("Whereabouts operations", func() {
 		// Gomega is cranky about slices with different caps
 		ExpectWithOffset(1, *result.IPs[0]).To(Equal(
 			current.IPConfig{
-				Version: "4",
 				Address: mustCIDR("192.168.33.1/28"),
 			}))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->

**What this PR does / why we need it**:

Given that we are now using contianernetworking/cni v1.1.2, we can move to the latest 100 type.
This PR moves to the newer type: "github.com/containernetworking/cni/pkg/types/100". The biggest change is the removal of the Version field. Components using this new type basically process the Address to verify the type.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

