### PR TITLE
Make podRef to be unique

### DIFF
--- a/pkg/allocate/allocate_test.go
+++ b/pkg/allocate/allocate_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		var exrange []string
-		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "default/newPod:fakeUID")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(newip)).To(Equal("192.168.1.1"))
 
@@ -43,7 +43,7 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		var exrange []string
-		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "default/newPod:fakeUID")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(newip)).To(Equal("caa5::1"))
 
@@ -59,7 +59,7 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		var exrange []string
-		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "default/newPod:fakeUID")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(newip)).To(Equal("::1"))
 
@@ -77,7 +77,7 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		var exrange []string
-		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "default/newPod:fakeUID")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(newip)).To(Equal("fd::1"))
 
@@ -93,7 +93,7 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		var exrange []string
-		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "default/newPod:fakeUID")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(newip)).To(Equal("100::2:1"))
 	})
@@ -108,7 +108,7 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		exrange := []string{"192.168.0.0/30"}
-		newip, _, _ := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		newip, _, _ := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "default/newPod:fakeUID")
 		Expect(fmt.Sprint(newip)).To(Equal("192.168.0.4"))
 
 	})
@@ -122,7 +122,7 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		exrange := []string{"192.168.0.1"}
-		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "default/newPod:fakeUID")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(newip)).To(Equal("192.168.0.2"))
 	})
@@ -136,7 +136,7 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		exrange := []string{"192.168.0.1/123"}
-		_, _, err = IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		_, _, err = IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "default/newPod:fakeUID")
 		Expect(err).To(MatchError(HavePrefix("could not parse exclude range")))
 	})
 
@@ -150,7 +150,7 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		exrange := []string{"100::2:1/126"}
-		newip, _, _ := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		newip, _, _ := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "default/newPod:fakeUID")
 		Expect(fmt.Sprint(newip)).To(Equal("100::2:4"))
 
 	})
@@ -164,7 +164,7 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		exrange := []string{"100::2:1"}
-		newip, _, _ := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		newip, _, _ := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "default/newPod:fakeUID")
 		Expect(fmt.Sprint(newip)).To(Equal("100::2:2"))
 	})
 
@@ -177,7 +177,7 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		exrange := []string{"100::2::1"}
-		_, _, err = IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		_, _, err = IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "default/newPod:fakeUID")
 		Expect(err).To(MatchError(HavePrefix("could not parse exclude range")))
 	})
 
@@ -191,7 +191,7 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		exrange := []string{"2001:db8::0/32"}
-		newip, _, _ := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		newip, _, _ := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "default/newPod:fakeUID")
 		Expect(fmt.Sprint(newip)).To(Equal("2001:db9::"))
 
 	})
@@ -206,11 +206,11 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		exrange := []string{"192.168.0.0/30", "192.168.0.6/31", "192.168.0.8/31", "192.168.0.4/30"}
-		newip, _, _ := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		newip, _, _ := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "default/newPod:fakeUID")
 		Expect(fmt.Sprint(newip)).To(Equal("192.168.0.10"))
 
 		exrange = []string{"192.168.0.0/30", "192.168.0.14/31", "192.168.0.4/30", "192.168.0.6/31", "192.168.0.8/31"}
-		newip, _, _ = IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "")
+		newip, _, _ = IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "default/newPod:fakeUID")
 		Expect(fmt.Sprint(newip)).To(Equal("192.168.0.10"))
 	})
 
@@ -222,19 +222,19 @@ var _ = Describe("Allocation operations", func() {
 		ipres := []types.IPReservation{
 			{
 				IP:     net.ParseIP("192.168.0.4"),
-				PodRef: "default/pod1",
+				PodRef: "default/pod1:fakeUID",
 			},
 			{
 				IP:     net.ParseIP("192.168.0.5"),
-				PodRef: "default/pod1",
+				PodRef: "default/pod1:fakeUID",
 			},
 			{
 				IP:     net.ParseIP("192.168.0.6"),
-				PodRef: "default/pod1",
+				PodRef: "default/pod1:fakeUID",
 			},
 		}
 		exrange := []string{"192.168.0.0/30"}
-		_, _, err = IterateForAssignment(*ipnet, firstip, nil, ipres, exrange, "0xdeadbeef", "")
+		_, _, err = IterateForAssignment(*ipnet, firstip, nil, ipres, exrange, "0xdeadbeef", "default/newPod:fakeUID")
 		Expect(err).To(MatchError(HavePrefix("Could not allocate IP in range")))
 
 	})
@@ -246,21 +246,45 @@ var _ = Describe("Allocation operations", func() {
 		ipres := []types.IPReservation{
 			{
 				IP:     net.ParseIP("192.168.0.1"),
-				PodRef: "default/pod1",
+				PodRef: "default/pod1:fakeUID",
 			},
 			{
 				IP:     net.ParseIP("192.168.0.2"),
-				PodRef: "default/pod1",
+				PodRef: "default/pod1:fakeUID",
 			},
 			{
 				IP:     net.ParseIP("192.168.0.3"),
-				PodRef: "default/pod1",
+				PodRef: "default/pod1:fakeUID",
 			},
 		}
 		exrange := []string{"192.168.0.4/30"}
-		_, _, err = IterateForAssignment(*ipnet, firstip, nil, ipres, exrange, "0xdeadbeef", "")
+		_, _, err = IterateForAssignment(*ipnet, firstip, nil, ipres, exrange, "0xdeadbeef", "default/newPod:fakeUID")
 		Expect(err).To(MatchError(HavePrefix("Could not allocate IP in range")))
 
+	})
+
+	It("can IterateForAssignment on an IPv4 address that has been allocated to the same pod", func() {
+
+		firstip, ipnet, err := net.ParseCIDR("192.168.0.0/29")
+		Expect(err).NotTo(HaveOccurred())
+		ip := net.ParseIP("192.168.0.2")
+
+		ipres := []types.IPReservation{
+			{
+				IP:     ip,
+				ContainerID: "0xdeadbeff",
+				PodRef: "default/pod2:fakeUID",
+			},
+			{
+				IP:     net.ParseIP("192.168.0.1"),
+				ContainerID: "0xdeadbfff",
+				PodRef: "default/pod1:fakeUID",
+			},
+		}
+		exrange := []string{"192.168.0.4/30"}
+		assignedIP, _, err := IterateForAssignment(*ipnet, firstip, nil, ipres, exrange, "0xdeadbeef", ipres[0].PodRef)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(assignedIP.String()).To(Equal(ip.String()))
 	})
 
 	It("can IterateForAssignment on an IPv6 address excluding a range and respect the requested range", func() {
@@ -271,20 +295,20 @@ var _ = Describe("Allocation operations", func() {
 		ipres := []types.IPReservation{
 			{
 				IP:     net.ParseIP("100::2:1"),
-				PodRef: "default/pod1",
+				PodRef: "default/pod1:fakeUID",
 			},
 			{
 				IP:     net.ParseIP("100::2:2"),
-				PodRef: "default/pod1",
+				PodRef: "default/pod1:fakeUID",
 			},
 			{
 				IP:     net.ParseIP("100::2:3"),
-				PodRef: "default/pod1",
+				PodRef: "default/pod1:fakeUID",
 			},
 		}
 
 		exrange := []string{"100::2:4/126"}
-		_, _, err = IterateForAssignment(*ipnet, firstip, nil, ipres, exrange, "0xdeadbeef", "")
+		_, _, err = IterateForAssignment(*ipnet, firstip, nil, ipres, exrange, "0xdeadbeef", "default/newPod:fakeUID")
 		Expect(err).To(MatchError(HavePrefix("Could not allocate IP in range")))
 
 	})
@@ -297,7 +321,7 @@ var _ = Describe("Allocation operations", func() {
 			_, ipnet, err := net.ParseCIDR("192.168.0.0/29")
 			Expect(err).NotTo(HaveOccurred())
 			rangeStart := net.ParseIP("192.168.0.0") // Network address, out of bounds.
-			newip, _, err := IterateForAssignment(*ipnet, rangeStart, nil, nil, nil, "0xdeadbeef", "")
+			newip, _, err := IterateForAssignment(*ipnet, rangeStart, nil, nil, nil, "0xdeadbeef", "default/newPod:fakeUID")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fmt.Sprint(newip)).To(Equal("192.168.0.1"))
 		})
@@ -309,7 +333,7 @@ var _ = Describe("Allocation operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 			rangeStart := net.ParseIP("192.168.0.0") // Network address, out of bounds.
 			rangeEnd := net.ParseIP("192.168.0.8")   // Broadcast address, out of bounds.
-			newip, _, err := IterateForAssignment(*ipnet, rangeStart, rangeEnd, nil, nil, "0xdeadbeef", "")
+			newip, _, err := IterateForAssignment(*ipnet, rangeStart, rangeEnd, nil, nil, "0xdeadbeef", "default/newPod:fakeUID")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fmt.Sprint(newip)).To(Equal("192.168.0.1"))
 		})
@@ -325,19 +349,19 @@ var _ = Describe("Allocation operations", func() {
 		ipres := []types.IPReservation{
 			{
 				IP:     net.ParseIP("192.168.0.1"),
-				PodRef: "default/pod1",
+				PodRef: "default/pod1:fakeUID",
 			},
 			{
 				IP:     net.ParseIP("192.168.0.2"),
-				PodRef: "default/pod1",
+				PodRef: "default/pod1:fakeUID",
 			},
 			{
 				IP:     net.ParseIP("192.168.0.3"),
-				PodRef: "default/pod1",
+				PodRef: "default/pod1:fakeUID",
 			},
 		}
 		exrange := []string{"192.168.0.4/30"}
-		_, _, err = IterateForAssignment(*ipnet, startip, lastip, ipres, exrange, "0xdeadbeef", "")
+		_, _, err = IterateForAssignment(*ipnet, startip, lastip, ipres, exrange, "0xdeadbeef", "default/newPod:fakeUID")
 		Expect(err).To(MatchError(HavePrefix("Could not allocate IP in range")))
 	})
 
@@ -367,15 +391,15 @@ var _ = Describe("Allocation operations", func() {
 				ipres := []types.IPReservation{
 					{
 						IP:     net.ParseIP("192.168.0.1"),
-						PodRef: "default/pod1",
+						PodRef: "default/pod1:fakeUID",
 					},
 					{
 						IP:     net.ParseIP("192.168.0.2"),
-						PodRef: "default/pod1",
+						PodRef: "default/pod1:fakeUID",
 					},
 					{
 						IP:     net.ParseIP("192.168.0.3"),
-						PodRef: "default/pod1",
+						PodRef: "default/pod1:fakeUID",
 					},
 				}
 
@@ -396,15 +420,15 @@ var _ = Describe("Allocation operations", func() {
 				ipres := []types.IPReservation{
 					{
 						IP:     net.ParseIP("192.168.0.1"),
-						PodRef: "default/pod1",
+						PodRef: "default/pod1:fakeUID",
 					},
 					{
 						IP:     net.ParseIP("192.168.0.2"),
-						PodRef: "default/pod1",
+						PodRef: "default/pod1:fakeUID",
 					},
 					{
 						IP:     net.ParseIP("192.168.0.5"),
-						PodRef: "default/pod1",
+						PodRef: "default/pod1:fakeUID",
 					},
 				}
 
@@ -414,5 +438,28 @@ var _ = Describe("Allocation operations", func() {
 				Expect(fmt.Sprint(ipres[3].IP)).To(Equal("192.168.0.3"))
 			})
 		})
+	})
+})
+
+var _ = Describe("Deallocation operations", func() {
+	It("can IterateForDeallocation on an IPv4 address", func() {
+
+		ip := net.ParseIP("192.168.0.1")
+		podRef := "default/pod1:fakeUID"
+		reservelist := []types.IPReservation{
+			{
+				IP:     ip,
+				PodRef: podRef,
+			},
+			{
+				IP:     net.ParseIP("192.168.0.2"),
+				PodRef: "default/pod2:fakeUID",
+			},
+		}
+
+		_, deallocatedIP, err := IterateForDeallocation(reservelist, podRef, getMatchingIPReservationIndex)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deallocatedIP.String()).To(Equal(ip.String()))
+
 	})
 })

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,6 +52,7 @@ func LoadIPAMConfig(bytes []byte, envArgs string, extraConfigPaths ...string) (*
 	}
 	n.IPAM.PodName = string(args.K8S_POD_NAME)
 	n.IPAM.PodNamespace = string(args.K8S_POD_NAMESPACE)
+	n.IPAM.PodUID = string(args.K8S_POD_UID)
 
 	flatipam, foundflatfile, err := GetFlatIPAM(false, n.IPAM, extraConfigPaths...)
 	if err != nil {

--- a/pkg/controlloop/entity_generators.go
+++ b/pkg/controlloop/entity_generators.go
@@ -1,5 +1,3 @@
-//go:build test
-// +build test
 
 package controlloop
 
@@ -10,6 +8,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types "k8s.io/apimachinery/pkg/types"
 
 	nad "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
@@ -58,12 +57,13 @@ func nodeSpec(name string) *v1.Node {
 	}
 }
 
-func podSpec(name string, namespace string, nodeName string, networks ...string) *v1.Pod {
+func podSpec(name string, namespace string, uid string, nodeName string, networks ...string) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   namespace,
 			Annotations: podNetworkSelectionElements(networks...),
+			UID:         types.UID(uid),
 		},
 		Spec: v1.PodSpec{
 			NodeName: nodeName,

--- a/pkg/reconciler/iploop.go
+++ b/pkg/reconciler/iploop.go
@@ -187,7 +187,7 @@ func (rl ReconcileLooper) convertLegacyPodRef(podRef string) (string, error) {
 	}
 	pod, err := rl.k8sClient.GetPod(podInfo[0], podInfo[1])
 	if err != nil {
-		return "", logging.Errorf("failed to get pod %s", pod.Name)
+		return "", logging.Errorf("failed to get pod %s", podInfo)
 	}
 	newPodRef := ComposePodRef(*pod)
 	logging.Debugf("converted podRef %s to %s", podRef, newPodRef)

--- a/pkg/reconciler/iploop_test.go
+++ b/pkg/reconciler/iploop_test.go
@@ -1,0 +1,108 @@
+package reconciler
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "k8s.io/client-go/kubernetes"
+	fakek8sclient "k8s.io/client-go/kubernetes/fake"
+
+	v1alpha1 "github.com/k8snetworkplumbingwg/whereabouts/pkg/api/whereabouts.cni.cncf.io/v1alpha1"
+	"github.com/k8snetworkplumbingwg/whereabouts/pkg/storage/kubernetes"
+
+	wbclient "github.com/k8snetworkplumbingwg/whereabouts/pkg/client/clientset/versioned"
+	fakewbclient "github.com/k8snetworkplumbingwg/whereabouts/pkg/client/clientset/versioned/fake"
+)
+
+var _ = Describe("MigrationPodRef", func() {
+	const (
+		firstIPInRange = "10.10.10.1"
+		ipRange        = "10.10.10.0/16"
+		namespace      = "default"
+		networkName    = "net1"
+		podName        = "pod1"
+		timeout        = 10
+		poolName       = "pool1"
+	)
+
+	var (
+		reconcileLooper *ReconcileLooper
+		k8sClientSet    k8sclient.Interface
+		pod             *v1.Pod
+	)
+
+	Context("When migration is needed", func() {
+		var (
+			pool     *v1alpha1.IPPool
+			wbClient wbclient.Interface
+			ctx      context.Context
+		)
+
+		BeforeEach(func() {
+			ctx = context.TODO()
+			pod = generatePod(namespace, podName, ipInNetwork{ip: firstIPInRange, networkName: networkName})
+			k8sClientSet = fakek8sclient.NewSimpleClientset(pod)
+			pool = generateLegacyIPPoolSpec(ipRange, namespace, poolName, pod)
+			wbClient = fakewbclient.NewSimpleClientset(pool)
+
+			ownerPodRef := ComposePodRef(*pod)
+			_, err := wbClient.WhereaboutsV1alpha1().OverlappingRangeIPReservations(namespace).Create(context.TODO(), generateClusterWideIPReservation(namespace, firstIPInRange, ownerPodRef), metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			reconcileLooper, err = NewReconcileLooperWithClient(context.TODO(), kubernetes.NewKubernetesClient(wbClient, k8sClientSet, timeout), timeout)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should update PodRef for overlappingrangeipreservations and pools", func() {
+			ipPools, err := reconcileLooper.k8sClient.ListIPPools(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			err = reconcileLooper.migrationPodRef(ctx, ipPools)
+			Expect(err).NotTo(HaveOccurred())
+
+			found := false
+			pattern := `^([^\s/]+)/([^\s/]+):([^\s/]+)$`
+			// Allippools shall have been updated
+			ipPools, err = reconcileLooper.k8sClient.ListIPPools(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			for _, pool := range ipPools {
+				for _, r := range pool.Allocations() {
+					if !regexp.MustCompile(pattern).MatchString(r.PodRef) {
+						found = true
+					}
+				}
+			}
+			Expect(found).To(BeFalse())
+			// All overlappingrangeipreservations shall have been updated
+			ips, err := reconcileLooper.k8sClient.ListOverlappingIPs(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			for _, ip := range ips {
+				if !regexp.MustCompile(pattern).MatchString(ip.Spec.PodRef) {
+					found = true
+				}
+			}
+			Expect(found).To(BeFalse())
+		})
+	})
+})
+
+func generateLegacyIPPoolSpec(ipRange string, namespace string, poolName string, pods ...*v1.Pod) *v1alpha1.IPPool {
+	allocations := map[string]v1alpha1.IPAllocation{}
+	for i, pod := range pods {
+		allocations[fmt.Sprintf("%d", i+1)] = v1alpha1.IPAllocation{
+			PodRef: fmt.Sprintf("%s/%s", pod.Namespace, pod.Name),
+		}
+	}
+	return &v1alpha1.IPPool{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: poolName, ResourceVersion: "1"},
+		Spec: v1alpha1.IPPoolSpec{
+			Range:       ipRange,
+			Allocations: allocations,
+		},
+	}
+}

--- a/pkg/reconciler/wrappedPod.go
+++ b/pkg/reconciler/wrappedPod.go
@@ -42,7 +42,7 @@ func indexPods(livePodList []v1.Pod, whereaboutsPodNames map[string]void) map[st
 	podMap := map[string]podWrapper{}
 
 	for _, pod := range livePodList {
-		podRef := composePodRef(pod)
+		podRef := ComposePodRef(pod)
 		if _, isWhereaboutsPod := whereaboutsPodNames[podRef]; !isWhereaboutsPod {
 			continue
 		}
@@ -64,7 +64,7 @@ func getFlatIPSet(pod v1.Pod) (map[string]void, error) {
 		return ipSet, logging.Errorf(
 			"could not parse network annotation %s for pod: %s; error: %v",
 			networkStatusAnnotationValue,
-			composePodRef(pod),
+			ComposePodRef(pod),
 			err)
 	}
 
@@ -76,7 +76,7 @@ func getFlatIPSet(pod v1.Pod) (map[string]void, error) {
 
 		for _, ip := range network.IPs {
 			ipSet[ip] = empty
-			logging.Debugf("Added IP %s for pod %s", ip, composePodRef(pod))
+			logging.Debugf("Added IP %s for pod %s", ip, ComposePodRef(pod))
 		}
 	}
 	return ipSet, nil

--- a/pkg/storage/kubernetes/ipam.go
+++ b/pkg/storage/kubernetes/ipam.go
@@ -200,13 +200,13 @@ func (i *KubernetesIPAM) GetOverlappingRangeStore() (storage.OverlappingRangeSto
 // IsAllocatedInOverlappingRange checks for IP addresses to see if they're allocated cluster wide, for overlapping
 // ranges.
 func (c *KubernetesOverlappingRangeStore) IsAllocatedInOverlappingRange(ctx context.Context, ip net.IP,
-	networkName string) (bool, error) {
+	networkName string, podRef string) (bool, error) {
 	normalizedIP := normalizeIP(ip, networkName)
 
 	logging.Debugf("OverlappingRangewide allocation check; normalized IP: %q, IP: %q, networkName: %q",
 		normalizedIP, ip, networkName)
 
-	_, err := c.client.WhereaboutsV1alpha1().OverlappingRangeIPReservations(c.namespace).Get(ctx, normalizedIP, metav1.GetOptions{})
+	reservedIP, err := c.client.WhereaboutsV1alpha1().OverlappingRangeIPReservations(c.namespace).Get(ctx, normalizedIP, metav1.GetOptions{})
 	if err != nil && errors.IsNotFound(err) {
 		// cluster ip reservation does not exist, this appears to be good news.
 		// logging.Debugf("IP %v is not reserved cluster wide, allowing.", ip)
@@ -214,6 +214,10 @@ func (c *KubernetesOverlappingRangeStore) IsAllocatedInOverlappingRange(ctx cont
 	} else if err != nil {
 		logging.Errorf("k8s get OverlappingRangeIPReservation error: %s", err)
 		return false, fmt.Errorf("k8s get OverlappingRangeIPReservation error: %s", err)
+	}
+	if reservedIP.Spec.PodRef == podRef {
+		logging.Debugf("IP %v is reserved for pod %s, allowing.", ip, podRef)
+		return false, nil
 	}
 
 	logging.Debugf("Normalized IP is reserved; normalized IP: %q, IP: %q, networkName: %q",
@@ -244,6 +248,20 @@ func (c *KubernetesOverlappingRangeStore) UpdateOverlappingRangeAllocation(ctx c
 
 		_, err = c.client.WhereaboutsV1alpha1().OverlappingRangeIPReservations(c.namespace).Create(
 			ctx, clusteripres, metav1.CreateOptions{})
+		if errors.IsAlreadyExists(err) {
+			var res *whereaboutsv1alpha1.OverlappingRangeIPReservation
+			res, err = c.client.WhereaboutsV1alpha1().OverlappingRangeIPReservations(c.namespace).Get(
+				ctx, normalizedIP, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			res.Spec = clusteripres.Spec
+			_, err = c.client.WhereaboutsV1alpha1().OverlappingRangeIPReservations(c.namespace).Update(
+				ctx, res, metav1.UpdateOptions{})
+			if err != nil {
+				return err
+			}
+		}
 
 	case whereaboutstypes.Deallocate:
 		verb = "deallocate"
@@ -525,7 +543,7 @@ func IPManagementKubernetesUpdate(ctx context.Context, mode int, ipam *Kubernete
 				// And we try again.
 				if ipamConf.OverlappingRanges {
 					isAllocated, err := overlappingrangestore.IsAllocatedInOverlappingRange(requestCtx, newip.IP,
-						ipamConf.NetworkName)
+						ipamConf.NetworkName, podRef)
 					if err != nil {
 						logging.Errorf("Error checking overlappingrange allocation: %v", err)
 						return newips, err
@@ -542,7 +560,7 @@ func IPManagementKubernetesUpdate(ctx context.Context, mode int, ipam *Kubernete
 				}
 
 			case whereaboutstypes.Deallocate:
-				updatedreservelist, ipforoverlappingrangeupdate, err = allocate.DeallocateIP(reservelist, containerID)
+				updatedreservelist, ipforoverlappingrangeupdate, err = allocate.DeallocateIP(reservelist, podRef)
 				if err != nil {
 					logging.Errorf("Error deallocating IP: %v", err)
 					return newips, err

--- a/pkg/storage/kubernetes/ipam.go
+++ b/pkg/storage/kubernetes/ipam.go
@@ -345,7 +345,7 @@ func (p *KubernetesIPPool) Update(ctx context.Context, reservations []whereabout
 
 // newLeaderElector creates a new leaderelection.LeaderElector and associated
 // channels by which to observe elections and depositions.
-func newLeaderElector(clientset kubernetes.Interface, namespace string, podNamespace string, podID string, leaseDuration int, renewDeadline int, retryPeriod int) (*leaderelection.LeaderElector, chan struct{}, chan struct{}) {
+func newLeaderElector(clientset kubernetes.Interface, namespace string, podNamespace string, podID string, podUID string, leaseDuration int, renewDeadline int, retryPeriod int) (*leaderelection.LeaderElector, chan struct{}, chan struct{}) {
 	//log.WithField("context", "leaderelection")
 	// leaderOK will block gRPC startup until it's closed.
 	leaderOK := make(chan struct{})
@@ -360,7 +360,7 @@ func newLeaderElector(clientset kubernetes.Interface, namespace string, podNames
 		},
 		Client: clientset.CoordinationV1(),
 		LockConfig: resourcelock.ResourceLockConfig{
-			Identity: fmt.Sprintf("%s/%s", podNamespace, podID),
+			Identity: fmt.Sprintf("%s/%s:%s", podNamespace, podID, podUID),
 		},
 	}
 
@@ -401,7 +401,7 @@ func IPManagement(ctx context.Context, mode int, ipamConf whereaboutstypes.IPAMC
 	}
 
 	// setup leader election
-	le, leader, deposed := newLeaderElector(client.clientSet, client.namespace, ipamConf.PodNamespace, ipamConf.PodName, ipamConf.LeaderLeaseDuration, ipamConf.LeaderRenewDeadline, ipamConf.LeaderRetryPeriod)
+	le, leader, deposed := newLeaderElector(client.clientSet, client.namespace, ipamConf.PodNamespace, ipamConf.PodName, ipamConf.PodUID, ipamConf.LeaderLeaseDuration, ipamConf.LeaderRenewDeadline, ipamConf.LeaderRetryPeriod)
 	var wg sync.WaitGroup
 	wg.Add(2)
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -33,7 +33,7 @@ type Store interface {
 
 // OverlappingRangeStore is an interface for wrapping overlappingrange storage options
 type OverlappingRangeStore interface {
-	IsAllocatedInOverlappingRange(ctx context.Context, ip net.IP, networkName string) (bool, error)
+	IsAllocatedInOverlappingRange(ctx context.Context, ip net.IP, networkName string, podRef string) (bool, error)
 	UpdateOverlappingRangeAllocation(ctx context.Context, mode int, ip net.IP, containerID string, podRef,
 		networkName string) error
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -70,6 +70,7 @@ type IPAMConfig struct {
 	ConfigurationPath        string           `json:"configuration_path"`
 	PodName                  string
 	PodNamespace             string
+	PodUID                   string
 	NetworkName              string `json:"network_name,omitempty"`
 }
 
@@ -106,6 +107,7 @@ func (ic *IPAMConfig) UnmarshalJSON(data []byte) error {
 		ConfigurationPath        string           `json:"configuration_path"`
 		PodName                  string
 		PodNamespace             string
+		PodUID                   string
 		NetworkName              string `json:"network_name,omitempty"`
 	}
 
@@ -142,13 +144,14 @@ func (ic *IPAMConfig) UnmarshalJSON(data []byte) error {
 		ConfigurationPath:        ipamConfigAlias.ConfigurationPath,
 		PodName:                  ipamConfigAlias.PodName,
 		PodNamespace:             ipamConfigAlias.PodNamespace,
+		PodUID:                   ipamConfigAlias.PodUID,
 		NetworkName:              ipamConfigAlias.NetworkName,
 	}
 	return nil
 }
 
 func (ic *IPAMConfig) GetPodRef() string {
-	return fmt.Sprintf("%s/%s", ic.PodNamespace, ic.PodName)
+	return fmt.Sprintf("%s/%s:%s", ic.PodNamespace, ic.PodName, ic.PodUID)
 }
 
 func backwardsCompatibleIPAddress(ip string) net.IP {
@@ -166,6 +169,7 @@ type IPAMEnvArgs struct {
 	GATEWAY                    cnitypes.UnmarshallableString `json:"gateway,omitempty"`
 	K8S_POD_NAME               cnitypes.UnmarshallableString //revive:disable-line
 	K8S_POD_NAMESPACE          cnitypes.UnmarshallableString //revive:disable-line
+	K8S_POD_UID                cnitypes.UnmarshallableString //revive:disable-line
 	K8S_POD_INFRA_CONTAINER_ID cnitypes.UnmarshallableString //revive:disable-line
 }
 


### PR DESCRIPTION
We used podRef with format \<namespace>/<pod_name> to identify the IP allocation. However, in scenarios like replicaSet, a different pod can reuse the pod name. This patch changes the format of podRef to \<namespace>/<pod_name>:<pod_uid> to ensure each ip allocation will have a unique identifier. The legacy podRef format will be updated automatically during an upgrade.

