### PR TITLE
Return the allocated IP to a pod with the same namespace/name

### DIFF
--- a/cmd/whereabouts.go
+++ b/cmd/whereabouts.go
@@ -70,7 +70,7 @@ func cmdAdd(args *skel.CmdArgs, client *kubernetes.KubernetesIPAM, cniVersion st
 	result.DNS = client.Config.DNS
 	result.Routes = client.Config.Routes
 
-	logging.Debugf("Beginning IPAM for ContainerID: %v", args.ContainerID)
+	logging.Debugf("Beginning IPAM for pod: %s/%s", client.Config.PodNamespace, client.Config.PodName)
 	var newips []net.IPNet
 
 	ctx, cancel := context.WithTimeout(context.Background(), types.AddTimeLimit)

--- a/e2e/client/replicaset.go
+++ b/e2e/client/replicaset.go
@@ -46,9 +46,9 @@ func isReplicaSetSteady(cs *kubernetes.Clientset, replicaSetName, namespace, lab
 }
 
 // check two things:
-// 1. number of pods that are ready should equal that of spec
-// 2. number of pods matching replicaSet's selector should equal that of spec
-//    (in 0 replicas case, replicas should finish terminating before this comes true)
+//  1. number of pods that are ready should equal that of spec
+//  2. number of pods matching replicaSet's selector should equal that of spec
+//     (in 0 replicas case, replicas should finish terminating before this comes true)
 func isReplicaSetSynchronized(replicaSet *appsv1.ReplicaSet, podList *corev1.PodList) bool {
 	return replicaSet.Status.ReadyReplicas == (*replicaSet.Spec.Replicas) && int32(len(podList.Items)) == (*replicaSet.Spec.Replicas)
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -447,6 +447,7 @@ var _ = Describe("Whereabouts functionality", func() {
 						Expect(decomposedPodRef).To(HaveLen(2))
 						podName := decomposedPodRef[1]
 
+						// Delete the pod with a grace period of 0, which could cause the pod deletion to happen later than the pod creation.
 						rightNow := int64(0)
 						Expect(clientInfo.Client.CoreV1().Pods(namespace).Delete(
 							context.TODO(), podName, metav1.DeleteOptions{GracePeriodSeconds: &rightNow})).To(Succeed())

--- a/pkg/allocate/allocate_test.go
+++ b/pkg/allocate/allocate_test.go
@@ -113,6 +113,28 @@ var _ = Describe("Allocation operations", func() {
 
 	})
 
+	It("can IterateForAssignment on an IPv4 address that has been allocated to a pod with the same podRef", func() {
+		podRef := "default/test-pod-1"
+		newID := "0xdeadffff"
+		firstip, ipnet, err := net.ParseCIDR("192.168.0.0/29")
+		Expect(err).NotTo(HaveOccurred())
+
+		// figure out the range start.
+		calculatedrangestart := net.ParseIP(firstip.Mask(ipnet.Mask).String())
+
+		ipres := []types.IPReservation{
+			{
+				IP:          net.ParseIP("192.168.0.4"),
+				ContainerID: newID,
+				PodRef:      podRef,
+			},
+		}
+		exrange := []string{}
+		newip, _, _ := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, newID, podRef)
+		Expect(fmt.Sprint(newip)).To(Equal("192.168.0.4"))
+		Expect(ipres[0].ContainerID).To(Equal(newID))
+	})
+
 	It("can IterateForAssignment on an IPv4 address excluding a range which is a single IP", func() {
 		firstip, ipnet, err := net.ParseCIDR("192.168.0.0/29")
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/reconciler/ip_test.go
+++ b/pkg/reconciler/ip_test.go
@@ -441,7 +441,7 @@ var _ = Describe("IPReconciler", func() {
 
 			It("errors when attempting to clean up the IP address", func() {
 				reconciledIPs, err := ipReconciler.ReconcileIPPools(context.TODO())
-				Expect(err).To(MatchError(fmt.Sprintf("did not find reserved IP for container %s", reservationPodRef)))
+				Expect(err).To(MatchError(fmt.Sprintf("did not find reserved IP for %s", reservationPodRef)))
 				Expect(reconciledIPs).To(BeEmpty())
 			})
 		})

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"time"
 
+	whereaboutsv1alpha1 "github.com/k8snetworkplumbingwg/whereabouts/pkg/api/whereabouts.cni.cncf.io/v1alpha1"
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/types"
 )
 
@@ -33,7 +34,7 @@ type Store interface {
 
 // OverlappingRangeStore is an interface for wrapping overlappingrange storage options
 type OverlappingRangeStore interface {
-	IsAllocatedInOverlappingRange(ctx context.Context, ip net.IP, networkName string) (bool, error)
+	IsAllocatedInOverlappingRange(ctx context.Context, ip net.IP, networkName string) (*whereaboutsv1alpha1.OverlappingRangeIPReservation, error)
 	UpdateOverlappingRangeAllocation(ctx context.Context, mode int, ip net.IP, containerID string, podRef,
 		networkName string) error
 }


### PR DESCRIPTION
For statefulset pods, it will reuse the pod names after a node reboot. Whereabouts shall always return the same IP address that has already been allocated, when the pods start.

This patch also changes the IP deallocation logic. Now, the allocation record is identified by podRef instead of containerID.

