### PR TITLE
fix incorrect kubeconfig value in whereabouts.conf when not in defaul…

### DIFF
--- a/script/install-cni.sh
+++ b/script/install-cni.sh
@@ -20,7 +20,6 @@ WHEREABOUTS_RECONCILER_CRON=${WHEREABOUTS_RECONCILER_CRON:-30 4 * * *}
 mkdir -p $CNI_CONF_DIR/whereabouts.d
 WHEREABOUTS_KUBECONFIG=$CNI_CONF_DIR/whereabouts.d/whereabouts.kubeconfig
 WHEREABOUTS_FLATFILE=$CNI_CONF_DIR/whereabouts.d/whereabouts.conf # Yuki~ Nikhil's note: imo we should remove "flatfile" from whereabouts vocabulary and call this "WHEREABOUTS_CONF_FILE" instead. Flatfile may be the format but it's confusing naming.
-WHEREABOUTS_KUBECONFIG_LITERAL=$(echo "$WHEREABOUTS_KUBECONFIG" | sed -e s'|/host||')
 
 # ------------------------------- Generate a "kube-config"
 SERVICE_ACCOUNT_PATH=/var/run/secrets/kubernetes.io/serviceaccount
@@ -102,7 +101,7 @@ EOF
 {
   "datastore": "kubernetes",
   "kubernetes": {
-    "kubeconfig": "${WHEREABOUTS_KUBECONFIG_LITERAL}"
+    "kubeconfig": "${WHEREABOUTS_KUBECONFIG_FILE_HOST}"
   },
   "reconciler_cron_expression": "${WHEREABOUTS_RECONCILER_CRON}"
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->

**What this PR does / why we need it**:
https://github.com/k8snetworkplumbingwg/whereabouts/issues/465

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #465

**Special notes for your reviewer** *(optional)*:
Should have an explicit & reasonable way for the user to config the host path to different places e.g. k3s using /var/lib/rancher/k3s/agent/etc/cni/net.d/whereabouts.kubeconfig
