### PR TITLE
Align api calls timeouts cronjob ip reconciler

### DIFF
--- a/cmd/whereabouts_test.go
+++ b/cmd/whereabouts_test.go
@@ -57,8 +57,7 @@ func AllocateAndReleaseAddressesTest(ipRange string, gw string, kubeconfigPath s
 	wbClient := *kubernetes.NewKubernetesClient(
 		fake.NewSimpleClientset(
 			ipPool(conf.IPRanges[0].Range, podNamespace, ipamNetworkName)),
-		fakek8sclient.NewSimpleClientset(),
-		0)
+		fakek8sclient.NewSimpleClientset())
 
 	for i := 0; i < len(expectedAddresses); i++ {
 		name := fmt.Sprintf("%s-%d", podName, i)
@@ -164,8 +163,7 @@ var _ = Describe("Whereabouts operations", func() {
 			fake.NewSimpleClientset(
 				ipPool(ipamConf.IPRanges[0].Range, podNamespace, ipamNetworkName, []whereaboutstypes.IPReservation{
 					{PodRef: ipamConf.GetPodRef(), IfName: ifname, IP: net.ParseIP(expectedAddress)}, {PodRef: "test"}}...)),
-			fakek8sclient.NewSimpleClientset(),
-			0)
+			fakek8sclient.NewSimpleClientset())
 
 		cniConf, err := newCNINetConf(cniVersion, ipamConf)
 		Expect(err).NotTo(HaveOccurred())
@@ -928,8 +926,7 @@ var _ = Describe("Whereabouts operations", func() {
 		wbClient := *kubernetes.NewKubernetesClient(
 			fake.NewSimpleClientset(
 				ipPool(ipamConf.IPRanges[0].Range, podNamespace, ipamConf.NetworkName)),
-			fakek8sclient.NewSimpleClientset(),
-			0)
+			fakek8sclient.NewSimpleClientset())
 
 		// allocate 8 IPs (192.168.1.5 - 192.168.1.12); the entirety of the pool defined above
 		for i := 0; i < 8; i++ {
@@ -1000,8 +997,7 @@ var _ = Describe("Whereabouts operations", func() {
 		wbClient := *kubernetes.NewKubernetesClient(
 			fake.NewSimpleClientset(
 				ipPool(firstRange, podNamespace, ""), ipPool(secondRange, podNamespace, "")),
-			fakek8sclient.NewSimpleClientset(),
-			0)
+			fakek8sclient.NewSimpleClientset())
 
 		// ----------------------------- range 1
 
@@ -1124,8 +1120,7 @@ var _ = Describe("Whereabouts operations", func() {
 		wbClient := *kubernetes.NewKubernetesClient(
 			fake.NewSimpleClientset(
 				ipPool(firstRange, podNamespace, ""), ipPool(secondRange, podNamespace, "")),
-			fakek8sclient.NewSimpleClientset(),
-			0)
+			fakek8sclient.NewSimpleClientset())
 
 		// ----------------------------- range 1
 
@@ -1248,8 +1243,7 @@ var _ = Describe("Whereabouts operations", func() {
 		wbClient := *kubernetes.NewKubernetesClient(
 			fake.NewSimpleClientset(
 				ipPool(firstRange, podNamespace, ""), ipPool(secondRange, podNamespace, "")),
-			fakek8sclient.NewSimpleClientset(),
-			0)
+			fakek8sclient.NewSimpleClientset())
 
 		// ----------------------------- range 1
 
@@ -1373,7 +1367,7 @@ func newK8sIPAM(containerID, ifName string, ipamConf *whereaboutstypes.IPAMConfi
 	if err != nil {
 		return nil
 	}
-	k8sIPAM.Client = *kubernetes.NewKubernetesClient(wbClient, k8sCoreClient, 0)
+	k8sIPAM.Client = *kubernetes.NewKubernetesClient(wbClient, k8sCoreClient)
 	return k8sIPAM
 }
 

--- a/pkg/controlloop/pod.go
+++ b/pkg/controlloop/pod.go
@@ -225,7 +225,7 @@ func (pc *PodController) garbageCollectPodIPs(pod *v1.Pod) error {
 				if allocation.PodRef == podID(podNamespace, podName) {
 					logging.Verbosef("stale allocation to cleanup: %+v", allocation)
 
-					client := *wbclient.NewKubernetesClient(nil, pc.k8sClient, 0)
+					client := *wbclient.NewKubernetesClient(nil, pc.k8sClient)
 					wbClient := &wbclient.KubernetesIPAM{
 						Client: client,
 						Config: *ipamConfig,

--- a/pkg/reconciler/ip.go
+++ b/pkg/reconciler/ip.go
@@ -1,29 +1,20 @@
 package reconciler
 
 import (
-	"context"
-	"time"
-
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/logging"
-)
-
-const (
-	defaultReconcilerTimeout = 30
 )
 
 func ReconcileIPs(errorChan chan error) {
 	logging.Verbosef("starting reconciler run")
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(defaultReconcilerTimeout*time.Second))
-	defer cancel()
 
-	ipReconcileLoop, err := NewReconcileLooper(ctx, defaultReconcilerTimeout)
+	ipReconcileLoop, err := NewReconcileLooper()
 	if err != nil {
 		_ = logging.Errorf("failed to create the reconcile looper: %v", err)
 		errorChan <- err
 		return
 	}
 
-	cleanedUpIps, err := ipReconcileLoop.ReconcileIPPools(ctx)
+	cleanedUpIps, err := ipReconcileLoop.ReconcileIPPools()
 	if err != nil {
 		_ = logging.Errorf("failed to clean up IP for allocations: %v", err)
 		errorChan <- err
@@ -36,7 +27,7 @@ func ReconcileIPs(errorChan chan error) {
 		logging.Debugf("no IP addresses to cleanup")
 	}
 
-	if err := ipReconcileLoop.ReconcileOverlappingIPAddresses(ctx); err != nil {
+	if err := ipReconcileLoop.ReconcileOverlappingIPAddresses(); err != nil {
 		errorChan <- err
 		return
 	}

--- a/pkg/storage/kubernetes/ipam.go
+++ b/pkg/storage/kubernetes/ipam.go
@@ -61,7 +61,7 @@ func NewKubernetesIPAM(containerID, ifName string, ipamConf whereaboutstypes.IPA
 		return nil, fmt.Errorf("k8s config: namespace not present in context")
 	}
 
-	kubernetesClient, err := NewClientViaKubeconfig(ipamConf.Kubernetes.KubeConfigPath, storage.RequestTimeout)
+	kubernetesClient, err := NewClientViaKubeconfig(ipamConf.Kubernetes.KubeConfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed instantiating kubernetes client: %v", err)
 	}


### PR DESCRIPTION
Parent timeout context of 30s was removed. All listing operations used by the cronjob reconciler has 30s as timeout.

Fixes https://github.com/k8snetworkplumbingwg/whereabouts/issues/389