### PR TITLE
Fixes for node slice IPAM

### DIFF
--- a/pkg/allocate/allocate.go
+++ b/pkg/allocate/allocate.go
@@ -50,8 +50,8 @@ func AssignIP(ipamConf types.RangeConfiguration, reservelist []types.IPReservati
 }
 
 // DeallocateIP removes allocation from reserve list. Returns the updated reserve list and the deallocated IP.
-func DeallocateIP(reservelist []types.IPReservation, containerID string) ([]types.IPReservation, net.IP) {
-	index := getMatchingIPReservationIndex(reservelist, containerID)
+func DeallocateIP(reservelist []types.IPReservation, containerID, ifName string) ([]types.IPReservation, net.IP) {
+	index := getMatchingIPReservationIndex(reservelist, containerID, ifName)
 	if index < 0 {
 		// Allocation not found. Return the original reserve list and nil IP.
 		return reservelist, nil
@@ -63,9 +63,9 @@ func DeallocateIP(reservelist []types.IPReservation, containerID string) ([]type
 	return removeIdxFromSlice(reservelist, index), ip
 }
 
-func getMatchingIPReservationIndex(reservelist []types.IPReservation, id string) int {
+func getMatchingIPReservationIndex(reservelist []types.IPReservation, id, ifName string) int {
 	for idx, v := range reservelist {
-		if v.ContainerID == id {
+		if v.ContainerID == id && v.IfName == ifName {
 			return idx
 		}
 	}

--- a/pkg/iphelpers/iphelpers.go
+++ b/pkg/iphelpers/iphelpers.go
@@ -34,7 +34,7 @@ func CompareIPs(ipX net.IP, ipY net.IP) int {
 func DivideRangeBySize(inputNetwork string, sliceSizeString string) ([]string, error) {
 	// Remove "/" from the start of the sliceSize
 	sliceSizeString = strings.TrimPrefix(sliceSizeString, "/")
-	
+
 	sliceSize, err := strconv.Atoi(sliceSizeString)
 	if err != nil {
 		fmt.Println("Error:", err)
@@ -42,7 +42,7 @@ func DivideRangeBySize(inputNetwork string, sliceSizeString string) ([]string, e
 	}
 	ip, ipNet, err := net.ParseCIDR(inputNetwork)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error parsing CIDR %s: %v", inputNetwork, err)
 	}
 	if !ip.Equal(ipNet.IP) {
 		return nil, errors.New("netCIDR is not a valid network address")

--- a/pkg/storage/kubernetes/ipam.go
+++ b/pkg/storage/kubernetes/ipam.go
@@ -607,7 +607,7 @@ func IPManagementKubernetesUpdate(ctx context.Context, mode int, ipam *Kubernete
 					return newips, err
 				}
 				ipRange = whereaboutstypes.RangeConfiguration{
-					Range:      nodeSliceRange,
+					Range:      ipRange.Range,
 					RangeStart: rangeStart,
 					RangeEnd:   rangeEnd,
 				}

--- a/pkg/storage/kubernetes/ipam.go
+++ b/pkg/storage/kubernetes/ipam.go
@@ -658,7 +658,7 @@ func IPManagementKubernetesUpdate(ctx context.Context, mode int, ipam *Kubernete
 				}
 
 			case whereaboutstypes.Deallocate:
-				updatedreservelist, ipforoverlappingrangeupdate = allocate.DeallocateIP(reservelist, ipam.containerID)
+				updatedreservelist, ipforoverlappingrangeupdate = allocate.DeallocateIP(reservelist, ipam.containerID, ipam.IfName)
 				if ipforoverlappingrangeupdate == nil {
 					// Do not fail if allocation was not found.
 					logging.Debugf("Failed to find allocation for container ID: %s", ipam.containerID)


### PR DESCRIPTION
This fixes some issues seen with the new node slice IPAM feature.

1. Disable some controllers that are not needed. Don't need informer on nodeSlicePool since that is an internal CR we manage. Don't need to reconcile for NADs when the resource version does not change. For nodes, only listen for node add and delete. Nodes are updated frequently for Status changes and conditions that we don't need - we only want to allocate a new slice pool when a node is created, and remove its allocation when node is deleted

2. We have multiple NADs(which map to multiple NICs), but with the same CIDR and network_name(because it is really one L2 network). With node slice pool feature enabled and a Pod requesting multiple networks, the same podRef and same containerID will be present multiple times in each IPpool, for each ifName(corresponding to each NAD). We also need to match by ifName so it deletes the correct entry, rather than first one

3. When node slice size or cidr is reconfigured, it was passing the wrong range - ipam.Range, rather than ipamConf.IPRanges[0].Range. ipam.Range is cleared and set to ipamConf.IPRanges[0].Range so it was error'ing out with empty CIDR

4. nodeSlice.Spec was not being written/saved when the node slice size/cidr was reconfigured

5. the Subnet mask/cidr used was incorrect. We should use the CIDR from the NAD, rather than the range for the node. The NAD's range really defines the cluster-wide subnet, whereas the nodeSLicePool's IPRange is just used for grouping IP allocations. Without this fix, each node was on a different subnet, resulting in a IP lookup via default route(primary CNI), rather than going over the NAD/Multus network. For example, suppose our NAD range is 10.0.0.0/8. The node slice size is a /24. If we use the range from the NodeSLicePool, Pods on a node are on a different /24, rather than all being on the same /8. 
