### PR TITLE
Reduce Sleep

### DIFF
--- a/pkg/reconciler/iploop.go
+++ b/pkg/reconciler/iploop.go
@@ -118,7 +118,7 @@ func (rl ReconcileLooper) isOrphanedIP(podRef string, ip string) bool {
 							logging.Debugf("Pod now has IP annotation while in Pending")
 							return true
 						}
-						time.Sleep(time.Duration(500) * time.Millisecond)
+						time.Sleep(time.Duration(250) * time.Millisecond)
 					}
 				}
 				isFound = isIpOnPod(podToMatch, podRef, ip)


### PR DESCRIPTION
during the reconcilation loop we check to see if we have any orphaned Ips, and during this we currently have a 1.5 second sleep. I ran some tests and found a decent perf improvement by dropping this by half, but removing it completely caused issues


