### PR TITLE
Skip Static test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ COMPUTE_NODES ?= 2
 
 OCI_BIN ?= docker
 
+
 build:
 	hack/build-go.sh
 
@@ -23,7 +24,10 @@ install-tools:
 	hack/install-kubebuilder-tools.sh
 
 test: build install-tools
-	hack/test-go.sh
+	hack/test-go.sh 
+
+test-skip-static: build
+	hack/test-go.sh --skip-static-check 
 
 kind:
 	hack/e2e-setup-kind-cluster.sh -n $(COMPUTE_NODES)

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -1,20 +1,38 @@
 #!/usr/bin/env bash
 # single test: go test -v ./pkg/storage/
 # without cache: go test -count=1 -v ./pkg/storage/
-set -e -x
+set -eox pipefail
 
 GO=${GO:-go}
+SKIP_STATIC_CHECK=$false
+#parse args
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -s|--skip-static-check)
+      SKIP_STATIC_CHECK=true
+      shift
+      ;;
+    *)
+      echo "Invalid arguement: $1"
+      echo "Usage: $0 [-s|--skip-static-check]"
+      exit 1
+  esac
+done
 
 echo "Running go vet ..."
 ${GO} vet --tags=test ./cmd/... ./pkg/...
 
 BASEDIR=$(pwd)
 
-echo "Installing golang staticcheck ..."
-GOBIN=${BASEDIR}/bin go install honnef.co/go/tools/cmd/staticcheck@latest
-
-echo "Running golang staticcheck ..."
-${BASEDIR}/bin/staticcheck --tags=test ./...
+if [ $SKIP_STATIC_CHECK ]
+then
+    echo "Skipped golang staticcheck"
+else
+  echo "Installing golang staticcheck ..."
+  GOBIN=${BASEDIR}/bin go install honnef.co/go/tools/cmd/staticcheck@latest
+  echo "Running golang staticcheck ..."
+  ${BASEDIR}/bin/staticcheck --tags=test ./...
+fi
 
 echo "Running go tests..."
 KUBEBUILDER_ASSETS="$(pwd)/bin" ${GO} test \


### PR DESCRIPTION
In order to run upstream tests in a container with make test we need to be able to skip the static check


