### PR TITLE
Add trivy vulnerability scanner build step

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -18,6 +18,22 @@ jobs:
           push: false
           tags: ghcr.io/${{ github.repository }}:latest-amd64
           file: Dockerfile
+          
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ghcr.io/${{ github.repository }}:latest-amd64
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+  
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
 
   build-openshift:
     name: Image build/openshift


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->

**What this PR does / why we need it**:

This PR adds a step in the build pipeline to run the trivy vulnerabilty scanner on the latest image.
It also uploads the results so that they are displayed in the Security tab of the repository.

**Special notes for your reviewer** *(optional)*:

