### PR TITLE
🐛 Fixes leftover podref issue

### DIFF
--- a/pkg/controlloop/pod.go
+++ b/pkg/controlloop/pod.go
@@ -224,17 +224,16 @@ func (pc *PodController) garbageCollectPodIPs(pod *v1.Pod) error {
 				if allocation.PodRef == podID(podNamespace, podName) {
 					logging.Verbosef("stale allocation to cleanup: %+v", allocation)
 
-					client := *wbclient.NewKubernetesClient(nil, pc.k8sClient)
-					wbClient := &wbclient.KubernetesIPAM{
-						Client: client,
-						Config: *ipamConfig,
+					client := *wbclient.NewKubernetesClient(pc.wbClient, pc.k8sClient)
+					k8sIPAM := &wbclient.KubernetesIPAM{
+						Config:      *ipamConfig,
+						ContainerID: allocation.ContainerID,
+						IfName:      allocation.IfName,
+						Namespace:   pool.Namespace,
+						Client:      client,
 					}
 
-					if err != nil {
-						logging.Debugf("error while generating the IPAM client: %v", err)
-						continue
-					}
-					if _, err := pc.cleanupFunc(context.TODO(), types.Deallocate, *ipamConfig, wbClient); err != nil {
+					if _, err := pc.cleanupFunc(context.TODO(), types.Deallocate, *ipamConfig, k8sIPAM); err != nil {
 						logging.Errorf("failed to cleanup allocation: %v", err)
 					}
 					if err := pc.addressGarbageCollected(pod, nad.GetName(), pool.Spec.Range, allocationIndex); err != nil {
@@ -244,7 +243,6 @@ func (pc *PodController) garbageCollectPodIPs(pod *v1.Pod) error {
 			}
 		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->

**What this PR does / why we need it**:
Leader election fails when `IPManagement` is called from `garbageCollectPodIPs` in `pod.go`, this PR fixes the `KubernetesIPAM` and `Client` creation in `pod.go`, which resolves the leader election issue.



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/k8snetworkplumbingwg/whereabouts/issues/483

**Special notes for your reviewer** *(optional)*:

