### PR TITLE
Improve dependabot config with groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,15 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      k8s:
+        patterns: [ "k8s.io/*", "sigs.k8s.io/*" ]
+        update-types: [ "major", "minor", "patch" ]
+      other-go-modules:
+        patterns: [ "*" ]
+        exclude-patterns: 
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
   - package-ecosystem: docker
     directory: /
     schedule:


### PR DESCRIPTION
Follow up to my original PR: #331 

Improves the `go.mod` dependabot settings by grouping everything k8s related into its own PR.  All other dependencies will be in their own group.