### PR TITLE
Remove duplicate app label from helm chart

### DIFF
--- a/deployment/whereabouts-chart/templates/_helpers.tpl
+++ b/deployment/whereabouts-chart/templates/_helpers.tpl
@@ -45,7 +45,6 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "whereabouts.labels" -}}
-app: whereabouts
 helm.sh/chart: {{ include "whereabouts.chart" . }}
 {{ include "whereabouts.selectorLabels" . }}
 {{- if .Chart.AppVersion }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Only one `app` label should be set on kubernetes resources. fluxcd will refuse to install the chart with duplicate app labels. This removes a hardcoded app label and leaves the label based on the chart name in place.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #591 