### PR TITLE
node slice controller should only process valid whereabouts configs

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -205,3 +206,5 @@ const (
 	// Deallocate operation identifier
 	Deallocate = 1
 )
+
+var ErrNoIPRanges = errors.New("no IP ranges in whereabouts config")


### PR DESCRIPTION
If a net-attach-def with a whereabouts configuration was missing ranges, a comparison of the missing property would cause the node slice controller to crash

Given an invalid config, such as:

```
[fedora@kubecon-demo crds]$ cat ~/poison-nad.yml 
apiVersion: "k8s.cni.cncf.io/v1"
kind: NetworkAttachmentDefinition
metadata:
  name: poison-conf
spec:
  config: '{
       "name": "whereabouts-shim",
       "cniVersion": "0.3.1",
       "type": "bridge",
       "ipam": {
         "type": "whereabouts"
       }
      }'
```

We'd have the node slice controller bomb out when it went to make a comparison:

```
E0403 17:43:44.816992       1 panic.go:115] "Observed a panic" panic="runtime error: index out of range [0] with length 0" panicGoValue="runtime.boundsError{x:0, y:0, signed:true, code:0x0}" stacktrace=<
	goroutine 88 [running]:
[...snip...]
	/go/src/github.com/k8snetworkplumbingwg/whereabouts/pkg/node-controller/controller.go:526
[...snip...]
```

With line 526, being `return conf1.IPRanges[0].Range == conf2.IPRanges[0].Range && conf1.NodeSliceSize == conf2.NodeSliceSize`

So, I went added some checks that the range is there, otherwise, don't process it further.