### PR TITLE
Reconciler and status check optimizations

### DIFF
--- a/pkg/storage/kubernetes/ipam.go
+++ b/pkg/storage/kubernetes/ipam.go
@@ -464,6 +464,9 @@ func IPManagement(ctx context.Context, mode int, ipamConf whereaboutstypes.IPAMC
 
 	// setup leader election
 	le, leader, deposed := newLeaderElector(ctx, client.clientSet, client.Namespace, client)
+	if le == nil {
+		return nil, fmt.Errorf("whereabouts leader election failed")
+	}
 	var wg sync.WaitGroup
 	wg.Add(2)
 

--- a/pkg/storage/kubernetes/ipam.go
+++ b/pkg/storage/kubernetes/ipam.go
@@ -160,12 +160,6 @@ func (i *KubernetesIPAM) getPool(ctx context.Context, name string, iprange strin
 	return pool, nil
 }
 
-// Status tests connectivity to the kubernetes backend
-func (i *KubernetesIPAM) Status(ctx context.Context) error {
-	_, err := i.client.WhereaboutsV1alpha1().IPPools(i.Namespace).List(ctx, metav1.ListOptions{})
-	return err
-}
-
 // Close partially implements the Store interface
 func (i *KubernetesIPAM) Close() error {
 	return nil
@@ -562,12 +556,6 @@ func IPManagementKubernetesUpdate(ctx context.Context, mode int, ipam *Kubernete
 
 	requestCtx, requestCancel := context.WithTimeout(ctx, storage.RequestTimeout)
 	defer requestCancel()
-
-	// Check our connectivity first
-	if err := ipam.Status(requestCtx); err != nil {
-		logging.Errorf("IPAM connectivity error: %v", err)
-		return newips, err
-	}
 
 	// handle the ip add/del until successful
 	var overlappingrangeallocations []whereaboutstypes.IPReservation


### PR DESCRIPTION
A few optimization fixes:

 - return if leader election fails
 - no need for the costly list IPpools call at start of each IPAM to "test" API server connectivity. We get the IPpools anyways and use client-go leader election.
 - refactored the isOrphanedIP loop in reconciler and also noticed the logic was backwards for the return value. Fixed that and we can just do a map lookup rather the iterate through the entire livePod list which can be huge
