### PR TITLE
Bump go to 1.24 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/k8snetworkplumbingwg/whereabouts
 
-go 1.23
+go 1.24
+
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/containernetworking/cni v1.2.3


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->

**What this PR does / why we need it**:
Bump go to 1.24 in go.mod since more and more dependencies are migrating.

However, it is blocked for now by the lack of an `openshift/release:golang-1.24` image.

This will be solved when merging #606.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

