### PR TITLE
Fix chart and source command in scripts

### DIFF
--- a/deployment/whereabouts-chart/templates/daemonset.yaml
+++ b/deployment/whereabouts-chart/templates/daemonset.yaml
@@ -1,3 +1,4 @@
+# Dont'forget to update doc/crds/daemonset-install.yaml as well
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/deployment/whereabouts-chart/templates/daemonset.yaml
+++ b/deployment/whereabouts-chart/templates/daemonset.yaml
@@ -39,8 +39,9 @@ spec:
           command: [ "/bin/sh" ]
           args:
             - -c
-            - >
-              SLEEP=false /install-cni.sh &&
+            - |
+              SLEEP=false source /install-cni.sh
+              /token-watcher.sh &
               /ip-control-loop -log-level debug
           env:
           - name: NODENAME

--- a/deployment/whereabouts-chart/templates/node-slice-controller.yaml
+++ b/deployment/whereabouts-chart/templates/node-slice-controller.yaml
@@ -1,3 +1,4 @@
+# Dont'forget to update doc/crds/node-slice-controller.yaml as well
 {{- if .Values.nodeSliceController.enabled }}
 apiVersion: apps/v1
 kind: Deployment

--- a/doc/crds/daemonset-install.yaml
+++ b/doc/crds/daemonset-install.yaml
@@ -1,3 +1,4 @@
+# Dont'forget to update deployment/whereabouts-chart/templates/daemonset.yaml as well
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/doc/crds/node-slice-controller.yaml
+++ b/doc/crds/node-slice-controller.yaml
@@ -1,3 +1,4 @@
+# Dont'forget to update deployment/whereabouts-chart/templates/node-slice-controller.yaml as well
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/script/install-cni.sh
+++ b/script/install-cni.sh
@@ -10,7 +10,7 @@ set -u -e
 #
 #SPDX-License-Identifier: Apache-2.0
 
-source lib.sh
+source /lib.sh
 
 # Setup our logging routines
 

--- a/script/token-watcher.sh
+++ b/script/token-watcher.sh
@@ -2,7 +2,7 @@
 
 set -u -e
 
-source lib.sh
+source /lib.sh
 
 echo "Sleep and Watching for service account token and CA file changes..."
 # enter sleep/watch loop


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->
- Align the chart with the daemonset manifest
- Fix source command in scripts: In busybox-based images, source does not look in the current directory so an absolute path is needed.
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

