### PR TITLE
Add priorityClassName support to Helm chart

### DIFF
--- a/deployment/whereabouts-chart/templates/daemonset.yaml
+++ b/deployment/whereabouts-chart/templates/daemonset.yaml
@@ -25,6 +25,9 @@ spec:
     spec:
       hostNetwork: true
       serviceAccountName: {{ include "whereabouts.serviceAccountName" . }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deployment/whereabouts-chart/templates/node-slice-controller.yaml
+++ b/deployment/whereabouts-chart/templates/node-slice-controller.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         app: {{ include "whereabouts.fullname" . }}-controller
     spec:
+      {{- with .Values.nodeSliceController.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       containers:
         - command:
             - /node-slice-controller

--- a/deployment/whereabouts-chart/values.yaml
+++ b/deployment/whereabouts-chart/values.yaml
@@ -49,9 +49,12 @@ tolerations:
 
 affinity: {}
 
+priorityClassName: ""
+
 cniConf:
   confDir: /etc/cni/net.d
   binDir: /opt/cni/bin
 
 nodeSliceController:
   enabled: true
+  priorityClassName: ""


### PR DESCRIPTION
**What this PR does / why we need it**:

To make sure we can mark daemonsets pods as first priority to be scheduled before the apps we need to support `priorityClassName` field.

By default, it won't be added.


