### PR TITLE
make reconciler process default iface

### DIFF
--- a/hack/install-kubebuilder-tools.sh
+++ b/hack/install-kubebuilder-tools.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 BASEDIR=$(pwd)
 
 # install controller-gen

--- a/pkg/controlloop/pod.go
+++ b/pkg/controlloop/pod.go
@@ -184,8 +184,7 @@ func (pc *PodController) garbageCollectPodIPs(pod *v1.Pod) error {
 	}
 
 	for _, ifaceStatus := range ifaceStatuses {
-		if ifaceStatus.Default {
-			logging.Verbosef("skipped net-attach-def for default network")
+		if !strings.Contains(ifaceStatus.Name, "/") {
 			continue
 		}
 		nad, err := pc.ifaceNetAttachDef(ifaceStatus)

--- a/pkg/reconciler/ip_test.go
+++ b/pkg/reconciler/ip_test.go
@@ -537,7 +537,7 @@ func generatePodNetworkStatusAnnotation(ipNetworks ...ipInNetwork) string {
 	var networkStatus []multusv1.NetworkStatus
 	for i, ipNetworkInfo := range ipNetworks {
 		networkStatus = append(networkStatus, multusv1.NetworkStatus{
-			Name:      ipNetworkInfo.networkName,
+			Name:      "default/" + ipNetworkInfo.networkName,
 			Interface: fmt.Sprintf("net%d", i+1),
 			IPs:       []string{ipNetworkInfo.ip},
 		})

--- a/pkg/reconciler/wrappedPod.go
+++ b/pkg/reconciler/wrappedPod.go
@@ -2,6 +2,7 @@ package reconciler
 
 import (
 	"encoding/json"
+	"strings"
 
 	k8snetworkplumbingwgv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/logging"
@@ -84,11 +85,9 @@ func getFlatIPSet(pod v1.Pod) (map[string]void, error) {
 	}
 
 	for _, network := range networkStatusList {
-		// we're only after multus secondary interfaces
-		if network.Default {
+		if !strings.Contains(network.Name, "/") {
 			continue
 		}
-
 		for _, ip := range network.IPs {
 			ipSet[ip] = empty
 			logging.Debugf("Added IP %s for pod %s", ip, composePodRef(pod))

--- a/pkg/reconciler/wrappedPod_test.go
+++ b/pkg/reconciler/wrappedPod_test.go
@@ -17,6 +17,7 @@ import (
 var _ = Describe("Pod Wrapper operations", func() {
 	generateDefaultNetworkStatus := func(ip string) k8snetworkplumbingwgv1.NetworkStatus {
 		return k8snetworkplumbingwgv1.NetworkStatus{
+			Name:    "default/foo",
 			IPs:     []string{ip},
 			Default: true,
 		}
@@ -24,7 +25,7 @@ var _ = Describe("Pod Wrapper operations", func() {
 
 	generateMultusNetworkStatus := func(ifaceName string, networkName string, ip string) k8snetworkplumbingwgv1.NetworkStatus {
 		return k8snetworkplumbingwgv1.NetworkStatus{
-			Name:      networkName,
+			Name:      "default/" + networkName,
 			Interface: ifaceName,
 			IPs:       []string{ip},
 		}
@@ -97,7 +98,7 @@ var _ = Describe("Pod Wrapper operations", func() {
 			table.Entry("when the annotation has multiple multus networks", "192.168.14.14", "10.10.10.10"),
 		)
 
-		It("should skip the default network annotations", func() {
+		It("should not skip the default network annotations", func() {
 			secondaryIfacesNetworkStatuses := generateMultusNetworkStatusList("192.168.14.14", "10.10.10.10")
 
 			networkStatus := append(
@@ -110,8 +111,8 @@ var _ = Describe("Pod Wrapper operations", func() {
 			}
 
 			podSecondaryIPs := wrapPod(pod).ips
-			Expect(podSecondaryIPs).To(HaveLen(2))
-			Expect(podSecondaryIPs).To(Equal(map[string]void{"192.168.14.14": {}, "10.10.10.10": {}}))
+			Expect(podSecondaryIPs).To(HaveLen(3))
+			Expect(podSecondaryIPs).To(Equal(map[string]void{"192.168.14.14": {}, "10.10.10.10": {}, "14.15.16.20": {}}))
 		})
 
 		It("return an empty list when the network annotations of a pod are invalid", func() {


### PR DESCRIPTION
Allow whereabouts to be used for the default interface (e.g. when a pod/VM does not reside on the pod network).

**What this PR does / why we need it**:

To support a use-case when it is not desirable to expose a pod/VM on the pod network.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #638

**Special notes for your reviewer** *(optional)*:

Pod reconciler used to ignore the default iface, which led to garbage collection of valid IPs. With this change it considers any network referencing a net-attach-dev and relies on the fact that the network name in `network-status` is set to `$namespace/$name`

If there's a use-case where whereabouts needs to used without multus, then this will need to be reworked. Please let me know.