### PR TITLE
single-ip allocation and network/broadcast address inclusion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build:
 	hack/build-go.sh
 
 docker-build:
-	$(OCI_BIN) build -t ${IMAGE_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} -f Dockerfile --platform linux/amd64 .
+	$(OCI_BIN) build -t ${IMAGE_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} -f Dockerfile .
 
 generate-api:
 	hack/verify-codegen.sh

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build:
 	hack/build-go.sh
 
 docker-build:
-	$(OCI_BIN) build -t ${IMAGE_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} -f Dockerfile .
+	$(OCI_BIN) build -t ${IMAGE_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} -f Dockerfile --platform linux/amd64 .
 
 generate-api:
 	hack/verify-codegen.sh

--- a/cmd/whereabouts_test.go
+++ b/cmd/whereabouts_test.go
@@ -980,7 +980,8 @@ var _ = Describe("Whereabouts operations", func() {
 		Expect(err).To(HaveOccurred())
 
 		// ensure the error is of the correct type
-		if assignErr := new(allocate.AssignmentError); !errors.As(err, &assignErr) {
+		var assignErr *allocate.AssignmentError
+		if !errors.As(err, &assignErr) {
 			Fail(fmt.Sprintf("expected AssignmentError, got: %s", err))
 		}
 	})

--- a/cmd/whereabouts_test.go
+++ b/cmd/whereabouts_test.go
@@ -980,10 +980,8 @@ var _ = Describe("Whereabouts operations", func() {
 		Expect(err).To(HaveOccurred())
 
 		// ensure the error is of the correct type
-		switch e := errors.Unwrap(err); e.(type) {
-		case allocate.AssignmentError:
-		default:
-			Fail(fmt.Sprintf("expected AssignmentError, got: %s", e))
+		if assignErr := new(allocate.AssignmentError); !errors.As(err, &assignErr) {
+			Fail(fmt.Sprintf("expected AssignmentError, got: %s", err))
 		}
 	})
 

--- a/cmd/whereabouts_test.go
+++ b/cmd/whereabouts_test.go
@@ -980,8 +980,7 @@ var _ = Describe("Whereabouts operations", func() {
 		Expect(err).To(HaveOccurred())
 
 		// ensure the error is of the correct type
-		var assignErr *allocate.AssignmentError
-		if !errors.As(err, &assignErr) {
+		if !errors.As(err, new(allocate.AssignmentError)) {
 			Fail(fmt.Sprintf("expected AssignmentError, got: %s", err))
 		}
 	})

--- a/e2e/util/util.go
+++ b/e2e/util/util.go
@@ -147,7 +147,7 @@ func GenerateNetAttachDefSpec(name, namespace, config string) *nettypes.NetworkA
 	}
 }
 
-func MacvlanNetworkWithWhereaboutsIPAMNetwork(networkName string, namespaceName string, ipRange string, ipRanges []string, poolName string, enableOverlappingRanges bool) *nettypes.NetworkAttachmentDefinition {
+func MacvlanNetworkWithWhereaboutsIPAMNetwork(networkName string, namespaceName string, ipRange string, ipRanges []string, poolName string, enableOverlappingRanges, singleIP bool) *nettypes.NetworkAttachmentDefinition {
 	macvlanConfig := fmt.Sprintf(`{
         "cniVersion": "0.3.0",
         "disableCheck": true,
@@ -166,11 +166,12 @@ func MacvlanNetworkWithWhereaboutsIPAMNetwork(networkName string, namespaceName 
                     "log_level": "debug",
                     "log_file": "/tmp/wb",
                     "network_name": "%s",
-                    "enable_overlapping_ranges": %v
+                    "enable_overlapping_ranges": %v,
+					"singleIP": %t
                 }
             }
         ]
-    }`, ipRange, CreateIPRanges(ipRanges), poolName, enableOverlappingRanges)
+    }`, ipRange, CreateIPRanges(ipRanges), poolName, enableOverlappingRanges, singleIP)
 	return GenerateNetAttachDefSpec(networkName, namespaceName, macvlanConfig)
 }
 

--- a/pkg/allocate/allocate.go
+++ b/pkg/allocate/allocate.go
@@ -41,7 +41,17 @@ func AssignIP(ipamConf types.RangeConfiguration, reservelist []types.IPReservati
 		}
 	}
 
-	newip, updatedreservelist, err := IterateForAssignment(*ipnet, ipamConf.RangeStart, ipamConf.IncludeNetworkAddress, ipamConf.RangeEnd, ipamConf.IncludeBroadcastAddress, reservelist, ipamConf.OmitRanges, containerID, podRef, ifName)
+	pool := types.Pool{
+		IPNet: *ipnet,
+
+		RangeStart:            ipamConf.RangeStart,
+		IncludeNetworkAddress: ipamConf.IncludeNetworkAddress,
+
+		RangeEnd:                ipamConf.RangeEnd,
+		IncludeBroadcastAddress: ipamConf.IncludeBroadcastAddress,
+	}
+
+	newip, updatedreservelist, err := IterateForAssignment(pool, reservelist, ipamConf.OmitRanges, containerID, podRef, ifName)
 	if err != nil {
 		return net.IPNet{}, nil, err
 	}
@@ -83,15 +93,15 @@ func removeIdxFromSlice(s []types.IPReservation, i int) []types.IPReservation {
 // If rangeEnd is specified, it is respected if it lies within the ipnet and if it is >= rangeStart.
 // reserveList holds a list of reserved IPs.
 // excludeRanges holds a list of subnets to be excluded (meaning the full subnet, including the network and broadcast IP).
-func IterateForAssignment(ipnet net.IPNet, rangeStart net.IP, includeNetworkAddress bool, rangeEnd net.IP, includeBroadcastAddress bool, reserveList []types.IPReservation, excludeRanges []string, containerID, podRef, ifName string) (net.IP, []types.IPReservation, error) {
+func IterateForAssignment(pool types.Pool, reserveList []types.IPReservation, excludeRanges []string, containerID, podRef, ifName string) (net.IP, []types.IPReservation, error) {
 	// Get the valid range, delimited by the ipnet's first and last usable IP as well as the rangeStart and rangeEnd.
-	firstIP, lastIP, err := iphelpers.GetIPRange(ipnet, rangeStart, includeNetworkAddress, rangeEnd, includeBroadcastAddress)
+	firstIP, lastIP, err := iphelpers.GetIPRange(pool)
 	if err != nil {
 		logging.Errorf("GetIPRange request failed with: %v", err)
 		return net.IP{}, reserveList, err
 	}
 	logging.Debugf("IterateForAssignment input >> range_start: %v | range_end: %v | ipnet: %v | first IP: %v | last IP: %v",
-		rangeStart, rangeEnd, ipnet.String(), firstIP, lastIP)
+		pool.RangeStart, pool.RangeEnd, pool.IPNet.String(), firstIP, lastIP)
 
 	// Build reserved map.
 	reserved := make(map[string]bool)
@@ -100,7 +110,7 @@ func IterateForAssignment(ipnet net.IPNet, rangeStart net.IP, includeNetworkAddr
 	}
 
 	// Build excluded list, "192.168.2.229/30", "192.168.1.229/30".
-	excluded := []*net.IPNet{}
+	excluded := make([]*net.IPNet, 0, len(excludeRanges))
 	for _, v := range excludeRanges {
 		subnet, err := parseExcludedRange(v)
 		if err != nil {
@@ -111,7 +121,7 @@ func IterateForAssignment(ipnet net.IPNet, rangeStart net.IP, includeNetworkAddr
 
 	// Iterate over every IP address in the range, accounting for reserved IPs and exclude ranges. Make sure that ip is
 	// within ipnet, and make sure that ip is smaller than lastIP.
-	for ip := firstIP; ipnet.Contains(ip) && iphelpers.CompareIPs(ip, lastIP) <= 0; ip = iphelpers.IncIP(ip) {
+	for ip := firstIP; pool.IPNet.Contains(ip) && iphelpers.CompareIPs(ip, lastIP) <= 0; ip = iphelpers.IncIP(ip) {
 		// If already reserved, skip it.
 		if reserved[ip.String()] {
 			continue
@@ -129,7 +139,7 @@ func IterateForAssignment(ipnet net.IPNet, rangeStart net.IP, includeNetworkAddr
 	}
 
 	// No IP address for assignment found, return an error.
-	return net.IP{}, reserveList, AssignmentError{firstIP, lastIP, ipnet, excludeRanges}
+	return net.IP{}, reserveList, AssignmentError{firstIP, lastIP, pool.IPNet, excludeRanges}
 }
 
 // skipExcludedSubnets iterates through all subnets and checks if ip is part of them. If i is part of one of the subnets,

--- a/pkg/allocate/allocate.go
+++ b/pkg/allocate/allocate.go
@@ -41,7 +41,7 @@ func AssignIP(ipamConf types.RangeConfiguration, reservelist []types.IPReservati
 		}
 	}
 
-	newip, updatedreservelist, err := IterateForAssignment(*ipnet, ipamConf.RangeStart, ipamConf.RangeEnd, reservelist, ipamConf.OmitRanges, containerID, podRef, ifName)
+	newip, updatedreservelist, err := IterateForAssignment(*ipnet, ipamConf.RangeStart, ipamConf.IncludeNetworkAddress, ipamConf.RangeEnd, ipamConf.IncludeBroadcastAddress, reservelist, ipamConf.OmitRanges, containerID, podRef, ifName)
 	if err != nil {
 		return net.IPNet{}, nil, err
 	}
@@ -83,9 +83,9 @@ func removeIdxFromSlice(s []types.IPReservation, i int) []types.IPReservation {
 // If rangeEnd is specified, it is respected if it lies within the ipnet and if it is >= rangeStart.
 // reserveList holds a list of reserved IPs.
 // excludeRanges holds a list of subnets to be excluded (meaning the full subnet, including the network and broadcast IP).
-func IterateForAssignment(ipnet net.IPNet, rangeStart net.IP, rangeEnd net.IP, reserveList []types.IPReservation, excludeRanges []string, containerID, podRef, ifName string) (net.IP, []types.IPReservation, error) {
+func IterateForAssignment(ipnet net.IPNet, rangeStart net.IP, includeNetworkAddress bool, rangeEnd net.IP, includeBroadcastAddress bool, reserveList []types.IPReservation, excludeRanges []string, containerID, podRef, ifName string) (net.IP, []types.IPReservation, error) {
 	// Get the valid range, delimited by the ipnet's first and last usable IP as well as the rangeStart and rangeEnd.
-	firstIP, lastIP, err := iphelpers.GetIPRange(ipnet, rangeStart, rangeEnd)
+	firstIP, lastIP, err := iphelpers.GetIPRange(ipnet, rangeStart, includeNetworkAddress, rangeEnd, includeBroadcastAddress)
 	if err != nil {
 		logging.Errorf("GetIPRange request failed with: %v", err)
 		return net.IP{}, reserveList, err

--- a/pkg/allocate/allocate_test.go
+++ b/pkg/allocate/allocate_test.go
@@ -27,7 +27,13 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		var exrange []string
-		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "", "")
+
+		pool := types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: calculatedrangestart,
+		}
+
+		newip, _, err := IterateForAssignment(pool, ipres, exrange, "0xdeadbeef", "", "")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(newip)).To(Equal("192.168.1.1"))
 
@@ -43,7 +49,13 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		var exrange []string
-		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "", "")
+
+		pool := types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: calculatedrangestart,
+		}
+
+		newip, _, err := IterateForAssignment(pool, ipres, exrange, "0xdeadbeef", "", "")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(newip)).To(Equal("caa5::1"))
 
@@ -59,7 +71,13 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		var exrange []string
-		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "", "")
+
+		pool := types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: calculatedrangestart,
+		}
+
+		newip, _, err := IterateForAssignment(pool, ipres, exrange, "0xdeadbeef", "", "")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(newip)).To(Equal("::1"))
 
@@ -77,7 +95,13 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		var exrange []string
-		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "", "")
+
+		pool := types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: calculatedrangestart,
+		}
+
+		newip, _, err := IterateForAssignment(pool, ipres, exrange, "0xdeadbeef", "", "")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(newip)).To(Equal("fd::1"))
 
@@ -93,7 +117,13 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		var exrange []string
-		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "", "")
+
+		pool := types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: calculatedrangestart,
+		}
+
+		newip, _, err := IterateForAssignment(pool, ipres, exrange, "0xdeadbeef", "", "")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(newip)).To(Equal("100::2:1"))
 	})
@@ -108,7 +138,13 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		exrange := []string{"192.168.0.0/30"}
-		newip, _, _ := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "", "")
+
+		pool := types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: calculatedrangestart,
+		}
+
+		newip, _, _ := IterateForAssignment(pool, ipres, exrange, "0xdeadbeef", "", "")
 		Expect(fmt.Sprint(newip)).To(Equal("192.168.0.4"))
 
 	})
@@ -122,7 +158,13 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		exrange := []string{"192.168.0.1"}
-		newip, _, err := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "", "")
+
+		pool := types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: calculatedrangestart,
+		}
+
+		newip, _, err := IterateForAssignment(pool, ipres, exrange, "0xdeadbeef", "", "")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(newip)).To(Equal("192.168.0.2"))
 	})
@@ -135,8 +177,14 @@ var _ = Describe("Allocation operations", func() {
 		calculatedrangestart := net.ParseIP(firstip.Mask(ipnet.Mask).String())
 
 		var ipres []types.IPReservation
+
+		pool := types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: calculatedrangestart,
+		}
+
 		exrange := []string{"192.168.0.1/123"}
-		_, _, err = IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "", "")
+		_, _, err = IterateForAssignment(pool, ipres, exrange, "0xdeadbeef", "", "")
 		Expect(err).To(MatchError(HavePrefix("could not parse exclude range")))
 	})
 
@@ -150,7 +198,13 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		exrange := []string{"100::2:1/126"}
-		newip, _, _ := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "", "")
+
+		pool := types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: calculatedrangestart,
+		}
+
+		newip, _, _ := IterateForAssignment(pool, ipres, exrange, "0xdeadbeef", "", "")
 		Expect(fmt.Sprint(newip)).To(Equal("100::2:4"))
 
 	})
@@ -164,7 +218,13 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		exrange := []string{"100::2:1"}
-		newip, _, _ := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "", "")
+
+		pool := types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: calculatedrangestart,
+		}
+
+		newip, _, _ := IterateForAssignment(pool, ipres, exrange, "0xdeadbeef", "", "")
 		Expect(fmt.Sprint(newip)).To(Equal("100::2:2"))
 	})
 
@@ -177,7 +237,13 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		exrange := []string{"100::2::1"}
-		_, _, err = IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "", "")
+
+		pool := types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: calculatedrangestart,
+		}
+
+		_, _, err = IterateForAssignment(pool, ipres, exrange, "0xdeadbeef", "", "")
 		Expect(err).To(MatchError(HavePrefix("could not parse exclude range")))
 	})
 
@@ -191,7 +257,13 @@ var _ = Describe("Allocation operations", func() {
 
 		var ipres []types.IPReservation
 		exrange := []string{"2001:db8::0/32"}
-		newip, _, _ := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "", "")
+
+		pool := types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: calculatedrangestart,
+		}
+
+		newip, _, _ := IterateForAssignment(pool, ipres, exrange, "0xdeadbeef", "", "")
 		Expect(fmt.Sprint(newip)).To(Equal("2001:db9::"))
 
 	})
@@ -205,12 +277,17 @@ var _ = Describe("Allocation operations", func() {
 		calculatedrangestart := net.ParseIP(firstip.Mask(ipnet.Mask).String())
 
 		var ipres []types.IPReservation
+		pool := types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: calculatedrangestart,
+		}
+
 		exrange := []string{"192.168.0.0/30", "192.168.0.6/31", "192.168.0.8/31", "192.168.0.4/30"}
-		newip, _, _ := IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "", "")
+		newip, _, _ := IterateForAssignment(pool, ipres, exrange, "0xdeadbeef", "", "")
 		Expect(fmt.Sprint(newip)).To(Equal("192.168.0.10"))
 
 		exrange = []string{"192.168.0.0/30", "192.168.0.14/31", "192.168.0.4/30", "192.168.0.6/31", "192.168.0.8/31"}
-		newip, _, _ = IterateForAssignment(*ipnet, calculatedrangestart, nil, ipres, exrange, "0xdeadbeef", "", "")
+		newip, _, _ = IterateForAssignment(pool, ipres, exrange, "0xdeadbeef", "", "")
 		Expect(fmt.Sprint(newip)).To(Equal("192.168.0.10"))
 	})
 
@@ -233,8 +310,12 @@ var _ = Describe("Allocation operations", func() {
 				PodRef: "default/pod1",
 			},
 		}
+		pool := types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: firstip,
+		}
 		exrange := []string{"192.168.0.0/30"}
-		_, _, err = IterateForAssignment(*ipnet, firstip, nil, ipres, exrange, "0xdeadbeef", "", "")
+		_, _, err = IterateForAssignment(pool, ipres, exrange, "0xdeadbeef", "", "")
 		Expect(err).To(MatchError(HavePrefix("Could not allocate IP in range")))
 
 	})
@@ -257,8 +338,62 @@ var _ = Describe("Allocation operations", func() {
 				PodRef: "default/pod1",
 			},
 		}
+		pool := types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: firstip,
+		}
 		exrange := []string{"192.168.0.4/30"}
-		_, _, err = IterateForAssignment(*ipnet, firstip, nil, ipres, exrange, "0xdeadbeef", "", "")
+		_, _, err = IterateForAssignment(pool, ipres, exrange, "0xdeadbeef", "", "")
+		Expect(err).To(MatchError(HavePrefix("Could not allocate IP in range")))
+
+	})
+	It("can IterateForAssignment on an IPv4 address and respect the requested range with includeBroadcast option", func() {
+
+		firstip, ipnet, err := net.ParseCIDR("192.168.0.0/30")
+		Expect(err).NotTo(HaveOccurred())
+
+		ipres := []types.IPReservation{
+			{
+				IP:     net.ParseIP("192.168.0.1"),
+				PodRef: "default/pod1",
+			},
+		}
+		pool := types.Pool{
+			IPNet:                   *ipnet,
+			RangeStart:              firstip,
+			IncludeBroadcastAddress: true,
+		}
+		newip, _, err := IterateForAssignment(pool, ipres, nil, "0xdeadbeef", "", "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fmt.Sprint(newip)).To(Equal("192.168.0.2"))
+
+	})
+	It("can IterateForAssignment on an IPv4 address excluding the last allocatable IP and respect the requested range with includeBroadcast option", func() {
+
+		firstip, ipnet, err := net.ParseCIDR("192.168.0.0/29")
+		Expect(err).NotTo(HaveOccurred())
+
+		ipres := []types.IPReservation{
+			{
+				IP:     net.ParseIP("192.168.0.1"),
+				PodRef: "default/pod1",
+			},
+			{
+				IP:     net.ParseIP("192.168.0.2"),
+				PodRef: "default/pod1",
+			},
+			{
+				IP:     net.ParseIP("192.168.0.3"),
+				PodRef: "default/pod1",
+			},
+		}
+		pool := types.Pool{
+			IPNet:                   *ipnet,
+			RangeStart:              firstip,
+			IncludeBroadcastAddress: true,
+		}
+		exrange := []string{"192.168.0.4/30"}
+		_, _, err = IterateForAssignment(pool, ipres, exrange, "0xdeadbeef", "", "")
 		Expect(err).To(MatchError(HavePrefix("Could not allocate IP in range")))
 
 	})
@@ -283,8 +418,12 @@ var _ = Describe("Allocation operations", func() {
 			},
 		}
 
+		pool := types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: firstip,
+		}
 		exrange := []string{"100::2:4/126"}
-		_, _, err = IterateForAssignment(*ipnet, firstip, nil, ipres, exrange, "0xdeadbeef", "", "")
+		_, _, err = IterateForAssignment(pool, ipres, exrange, "0xdeadbeef", "", "")
 		Expect(err).To(MatchError(HavePrefix("Could not allocate IP in range")))
 
 	})
@@ -297,9 +436,29 @@ var _ = Describe("Allocation operations", func() {
 			_, ipnet, err := net.ParseCIDR("192.168.0.0/29")
 			Expect(err).NotTo(HaveOccurred())
 			rangeStart := net.ParseIP("192.168.0.0") // Network address, out of bounds.
-			newip, _, err := IterateForAssignment(*ipnet, rangeStart, nil, nil, nil, "0xdeadbeef", "", "")
+			pool := types.Pool{
+				IPNet:      *ipnet,
+				RangeStart: rangeStart,
+			}
+			newip, _, err := IterateForAssignment(pool, nil, nil, "0xdeadbeef", "", "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fmt.Sprint(newip)).To(Equal("192.168.0.1"))
+		})
+	})
+
+	When("no range_end is specified with includeNetwork option", func() {
+		It("the range start and end must be ignored if they are not within the bounds of the range for IPv4", func() {
+			_, ipnet, err := net.ParseCIDR("192.168.0.0/29")
+			Expect(err).NotTo(HaveOccurred())
+			rangeStart := net.ParseIP("192.168.0.0") // Network address,
+			pool := types.Pool{
+				IPNet:                 *ipnet,
+				RangeStart:            rangeStart,
+				IncludeNetworkAddress: true,
+			}
+			newip, _, err := IterateForAssignment(pool, nil, nil, "0xdeadbeef", "", "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fmt.Sprint(newip)).To(Equal("192.168.0.0"))
 		})
 	})
 
@@ -309,10 +468,55 @@ var _ = Describe("Allocation operations", func() {
 			Expect(err).NotTo(HaveOccurred())
 			rangeStart := net.ParseIP("192.168.0.0") // Network address, out of bounds.
 			rangeEnd := net.ParseIP("192.168.0.8")   // Broadcast address, out of bounds.
-			newip, _, err := IterateForAssignment(*ipnet, rangeStart, rangeEnd, nil, nil, "0xdeadbeef", "", "")
+			pool := types.Pool{
+				IPNet:      *ipnet,
+				RangeStart: rangeStart,
+				RangeEnd:   rangeEnd,
+			}
+			newip, _, err := IterateForAssignment(pool, nil, nil, "0xdeadbeef", "", "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fmt.Sprint(newip)).To(Equal("192.168.0.1"))
 		})
+	})
+	When("a range_end is specified with includeNetwork option", func() {
+		It("the range start and end must be ignored if they are not within the bounds of the range for IPv4", func() {
+			_, ipnet, err := net.ParseCIDR("192.168.0.0/29")
+			Expect(err).NotTo(HaveOccurred())
+			rangeStart := net.ParseIP("192.168.0.0") // Network address, out of bounds.
+			rangeEnd := net.ParseIP("192.168.0.8")   // Broadcast address, out of bounds.
+			pool := types.Pool{
+				IPNet:                 *ipnet,
+				RangeStart:            rangeStart,
+				RangeEnd:              rangeEnd,
+				IncludeNetworkAddress: true,
+			}
+			newip, _, err := IterateForAssignment(pool, nil, nil, "0xdeadbeef", "", "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fmt.Sprint(newip)).To(Equal("192.168.0.0"))
+		})
+	})
+
+	It("can IterateForAssignment on an IPv4 address with includeNetwork and includeBroadcast options", func() {
+		firstip, ipnet, err := net.ParseCIDR("192.168.0.0/31")
+		Expect(err).NotTo(HaveOccurred())
+
+		ipres := []types.IPReservation{
+			{
+				IP:     net.ParseIP("192.168.0.0"),
+				PodRef: "default/pod1",
+			},
+		}
+
+		pool := types.Pool{
+			IPNet:                   *ipnet,
+			RangeStart:              firstip,
+			IncludeNetworkAddress:   true,
+			IncludeBroadcastAddress: true,
+		}
+		newip, _, err := IterateForAssignment(pool, ipres, nil, "0xdeadbeef", "", "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fmt.Sprint(newip)).To(Equal("192.168.0.1"))
+
 	})
 
 	// Make sure that the end_range parameter is respected even when it is part of the exclude range.
@@ -337,7 +541,12 @@ var _ = Describe("Allocation operations", func() {
 			},
 		}
 		exrange := []string{"192.168.0.4/30"}
-		_, _, err = IterateForAssignment(*ipnet, startip, lastip, ipres, exrange, "0xdeadbeef", "", "")
+		pool := types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: startip,
+			RangeEnd:   lastip,
+		}
+		_, _, err = IterateForAssignment(pool, ipres, exrange, "0xdeadbeef", "", "")
 		Expect(err).To(MatchError(HavePrefix("Could not allocate IP in range")))
 	})
 
@@ -350,7 +559,12 @@ var _ = Describe("Allocation operations", func() {
 				lastip := net.ParseIP("192.168.0.6")
 
 				ipres := []types.IPReservation{}
-				_, ipres, err = IterateForAssignment(*ipnet, startip, lastip, ipres, nil, "0xdeadbeef", "dummy-0", "")
+				pool := types.Pool{
+					IPNet:      *ipnet,
+					RangeStart: startip,
+					RangeEnd:   lastip,
+				}
+				_, ipres, err = IterateForAssignment(pool, ipres, nil, "0xdeadbeef", "dummy-0", "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(ipres)).To(Equal(1))
 				Expect(fmt.Sprint(ipres[0].IP)).To(Equal("192.168.0.1"))
@@ -378,8 +592,12 @@ var _ = Describe("Allocation operations", func() {
 						PodRef: "default/pod1",
 					},
 				}
-
-				_, ipres, err = IterateForAssignment(*ipnet, startip, lastip, ipres, nil, "0xdeadbeef", "dummy-0", "")
+				pool := types.Pool{
+					IPNet:      *ipnet,
+					RangeStart: startip,
+					RangeEnd:   lastip,
+				}
+				_, ipres, err = IterateForAssignment(pool, ipres, nil, "0xdeadbeef", "dummy-0", "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(ipres)).To(Equal(4))
 				Expect(fmt.Sprint(ipres[3].IP)).To(Equal("192.168.0.4"))
@@ -408,7 +626,13 @@ var _ = Describe("Allocation operations", func() {
 					},
 				}
 
-				_, ipres, err = IterateForAssignment(*ipnet, startip, lastip, ipres, nil, "0xdeadbeef", "dummy-0", "")
+				pool := types.Pool{
+					IPNet:      *ipnet,
+					RangeStart: startip,
+					RangeEnd:   lastip,
+				}
+
+				_, ipres, err = IterateForAssignment(pool, ipres, nil, "0xdeadbeef", "dummy-0", "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(ipres)).To(Equal(4))
 				Expect(fmt.Sprint(ipres[3].IP)).To(Equal("192.168.0.3"))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -81,10 +81,12 @@ func LoadIPAMConfig(bytes []byte, envArgs string, extraConfigPaths ...string) (*
 	if n.IPAM.Range != "" {
 
 		oldRange := types.RangeConfiguration{
-			OmitRanges: n.IPAM.OmitRanges,
-			Range:      n.IPAM.Range,
-			RangeStart: n.IPAM.RangeStart,
-			RangeEnd:   n.IPAM.RangeEnd,
+			OmitRanges:              n.IPAM.OmitRanges,
+			Range:                   n.IPAM.Range,
+			RangeStart:              n.IPAM.RangeStart,
+			RangeEnd:                n.IPAM.RangeEnd,
+			IncludeNetworkAddress:   n.IPAM.IncludeNetworkAddress,
+			IncludeBroadcastAddress: n.IPAM.IncludeBroadcastAddress,
 		}
 
 		n.IPAM.IPRanges = append([]types.RangeConfiguration{oldRange}, n.IPAM.IPRanges...)

--- a/pkg/controlloop/dummy_controller.go
+++ b/pkg/controlloop/dummy_controller.go
@@ -54,7 +54,7 @@ func newDummyPodController(
 		netAttachDefInformerFactory,
 		nil,
 		recorder,
-		func(_ context.Context, _ int, ipamConfig types.IPAMConfig, client *kubeClient.KubernetesIPAM) ([]net.IPNet, error) {
+		func(_ context.Context, _ types.OperationType, ipamConfig types.IPAMConfig, client *kubeClient.KubernetesIPAM) ([]net.IPNet, error) {
 			ipPools := castToIPPool(wbInformerFactory.Whereabouts().V1alpha1().IPPools().Informer().GetStore().List())
 			for _, pool := range ipPools {
 				for index, allocation := range pool.Spec.Allocations {

--- a/pkg/controlloop/pod.go
+++ b/pkg/controlloop/pod.go
@@ -58,7 +58,7 @@ const (
 	noResyncPeriod                   = 0
 )
 
-type garbageCollector func(ctx context.Context, mode int, ipamConf types.IPAMConfig, client *wbclient.KubernetesIPAM) ([]net.IPNet, error)
+type garbageCollector func(ctx context.Context, mode types.OperationType, ipamConf types.IPAMConfig, client *wbclient.KubernetesIPAM) ([]net.IPNet, error)
 
 type PodController struct {
 	k8sClient               kubernetes.Interface

--- a/pkg/iphelpers/iphelpers.go
+++ b/pkg/iphelpers/iphelpers.go
@@ -146,30 +146,17 @@ func LastUsableIP(pool types.Pool) (net.IP, error) {
 	return ip, nil
 }
 
-// HasUsableIPs returns true if this subnet has usable IPs (i.e. not the network nor the broadcast IP).
+// HasUsableIPs returns true if this subnet has usable IPs (i.e. not the network nor the broadcast IP if not explicitly enabled).
 func HasUsableIPs(pool types.Pool) bool {
-	first := NetworkIP(pool.IPNet)
-	last := SubnetBroadcastIP(pool.IPNet)
-
-	if !pool.IncludeNetworkAddress {
-		first = IncIP(first)
-	}
-
-	if !pool.IncludeBroadcastAddress {
-		last = DecIP(last)
-	}
-
-	// Ensure both endpoints are still within the subnet
-	if !pool.IPNet.Contains(first) || !pool.IPNet.Contains(last) {
-		return false
-	}
+	ones, totalBits := pool.IPNet.Mask.Size()
 
 	expected := 1
 	if pool.IncludeNetworkAddress || pool.IncludeBroadcastAddress {
 		expected = 0
+		ones--
 	}
 
-	return CompareIPs(first, last) >= expected
+	return totalBits-ones > expected
 }
 
 // IncIP increases the given IP address by one. IncIP will overflow for all 0xf adresses.

--- a/pkg/iphelpers/iphelpers.go
+++ b/pkg/iphelpers/iphelpers.go
@@ -149,19 +149,14 @@ func LastUsableIP(pool types.Pool) (net.IP, error) {
 // HasUsableIPs returns true if this subnet has usable IPs (i.e. not the network nor the broadcast IP).
 func HasUsableIPs(pool types.Pool) bool {
 	ones, totalBits := pool.IPNet.Mask.Size()
-	if pool.IncludeNetworkAddress {
-		ones--
-	}
-	if pool.IncludeBroadcastAddress {
-		ones--
-	}
 
-	must := 1
+	expected := 1
 	if pool.IncludeNetworkAddress || pool.IncludeBroadcastAddress {
-		must = 0
+		expected = 0
+		ones--
 	}
 
-	return totalBits-ones > must
+	return totalBits-ones > expected
 }
 
 // IncIP increases the given IP address by one. IncIP will overflow for all 0xf adresses.

--- a/pkg/iphelpers/iphelpers.go
+++ b/pkg/iphelpers/iphelpers.go
@@ -155,7 +155,13 @@ func HasUsableIPs(pool types.Pool) bool {
 	if pool.IncludeBroadcastAddress {
 		ones--
 	}
-	return totalBits-ones > 1
+
+	must := 1
+	if pool.IncludeNetworkAddress || pool.IncludeBroadcastAddress {
+		must = 0
+	}
+
+	return totalBits-ones > must
 }
 
 // IncIP increases the given IP address by one. IncIP will overflow for all 0xf adresses.

--- a/pkg/iphelpers/iphelpers.go
+++ b/pkg/iphelpers/iphelpers.go
@@ -164,8 +164,12 @@ func HasUsableIPs(pool types.Pool) bool {
 		return false
 	}
 
-	// There are usable IPs iff first <= last
-	return CompareIPs(first, last) <= 0
+	expected := 1
+	if pool.IncludeNetworkAddress || pool.IncludeBroadcastAddress {
+		expected = 0
+	}
+
+	return CompareIPs(first, last) >= expected
 }
 
 // IncIP increases the given IP address by one. IncIP will overflow for all 0xf adresses.

--- a/pkg/iphelpers/iphelpers_test.go
+++ b/pkg/iphelpers/iphelpers_test.go
@@ -7,6 +7,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/k8snetworkplumbingwg/whereabouts/pkg/types"
 )
 
 const (
@@ -283,26 +285,34 @@ var _ = Describe("FirstUsableIP operations", func() {
 	Context("IPv4", func() {
 		It("throws an error when running FirstUsableIP for a /32", func() {
 			_, ipnet, _ := net.ParseCIDR("192.168.0.0/32")
-			_, err := FirstUsableIP(*ipnet)
+			_, err := FirstUsableIP(types.Pool{
+				IPNet: *ipnet,
+			})
 			Expect(err).To(MatchError(HavePrefix("net mask is too short")))
 		})
 
 		It("throws an error when running FirstUsableIP for a /31", func() {
 			_, ipnet, _ := net.ParseCIDR("192.168.0.0/31")
-			_, err := FirstUsableIP(*ipnet)
+			_, err := FirstUsableIP(types.Pool{
+				IPNet: *ipnet,
+			})
 			Expect(err).To(MatchError(HavePrefix("net mask is too short")))
 		})
 
 		It("correctly gets the FirstUsableIP for a /30", func() {
 			_, ipnet, _ := net.ParseCIDR("192.168.0.0/30")
-			ip, err := FirstUsableIP(*ipnet)
+			ip, err := FirstUsableIP(types.Pool{
+				IPNet: *ipnet,
+			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ip.To16()).To(Equal(net.ParseIP("192.168.0.1").To16()))
 		})
 
 		It("correctly gets the FirstUsableIP for a /23", func() {
 			_, ipnet, _ := net.ParseCIDR("192.168.0.0/23")
-			ip, err := FirstUsableIP(*ipnet)
+			ip, err := FirstUsableIP(types.Pool{
+				IPNet: *ipnet,
+			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ip.To16()).To(Equal(net.ParseIP("192.168.0.1").To16()))
 		})
@@ -311,26 +321,34 @@ var _ = Describe("FirstUsableIP operations", func() {
 	Context("IPv6", func() {
 		It("throws an error when running FirstUsableIP for a /128", func() {
 			_, ipnet, _ := net.ParseCIDR("2000::/128")
-			_, err := FirstUsableIP(*ipnet)
+			_, err := FirstUsableIP(types.Pool{
+				IPNet: *ipnet,
+			})
 			Expect(err).To(MatchError(HavePrefix("net mask is too short")))
 		})
 
 		It("throws an error when running FirstUsableIP for a /127", func() {
 			_, ipnet, _ := net.ParseCIDR("2000::/127")
-			_, err := FirstUsableIP(*ipnet)
+			_, err := FirstUsableIP(types.Pool{
+				IPNet: *ipnet,
+			})
 			Expect(err).To(MatchError(HavePrefix("net mask is too short")))
 		})
 
 		It("correctly gets the FirstUsableIP for a /126", func() {
 			_, ipnet, _ := net.ParseCIDR("2000::/126")
-			ip, err := FirstUsableIP(*ipnet)
+			ip, err := FirstUsableIP(types.Pool{
+				IPNet: *ipnet,
+			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ip.To16()).To(Equal(net.ParseIP("2000::1").To16()))
 		})
 
 		It("correctly gets the FirstUsableIP for a /64", func() {
 			_, ipnet, _ := net.ParseCIDR("2000::/64")
-			ip, err := FirstUsableIP(*ipnet)
+			ip, err := FirstUsableIP(types.Pool{
+				IPNet: *ipnet,
+			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ip.To16()).To(Equal(net.ParseIP("2000::1").To16()))
 		})
@@ -341,26 +359,34 @@ var _ = Describe("LastUsableIP operations", func() {
 	Context("IPv4", func() {
 		It("throws an error when running LastUsableIP for a /32", func() {
 			_, ipnet, _ := net.ParseCIDR("192.168.0.0/32")
-			_, err := LastUsableIP(*ipnet)
+			_, err := LastUsableIP(types.Pool{
+				IPNet: *ipnet,
+			})
 			Expect(err).To(MatchError(HavePrefix("net mask is too short")))
 		})
 
 		It("throws an error when running LastUsableIP for a /31", func() {
 			_, ipnet, _ := net.ParseCIDR("192.168.0.0/31")
-			_, err := LastUsableIP(*ipnet)
+			_, err := LastUsableIP(types.Pool{
+				IPNet: *ipnet,
+			})
 			Expect(err).To(MatchError(HavePrefix("net mask is too short")))
 		})
 
 		It("correctly gets the LastUsableIP for a /30", func() {
 			_, ipnet, _ := net.ParseCIDR("192.168.0.0/30")
-			ip, err := LastUsableIP(*ipnet)
+			ip, err := LastUsableIP(types.Pool{
+				IPNet: *ipnet,
+			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ip.To16()).To(Equal(net.ParseIP("192.168.0.2").To16()))
 		})
 
 		It("correctly gets the LastUsableIP for a /23", func() {
 			_, ipnet, _ := net.ParseCIDR("192.168.0.0/23")
-			ip, err := LastUsableIP(*ipnet)
+			ip, err := LastUsableIP(types.Pool{
+				IPNet: *ipnet,
+			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ip.To16()).To(Equal(net.ParseIP("192.168.1.254").To16()))
 		})
@@ -369,26 +395,34 @@ var _ = Describe("LastUsableIP operations", func() {
 	Context("IPv6", func() {
 		It("throws an error when running LastUsableIP for a /128", func() {
 			_, ipnet, _ := net.ParseCIDR("2000::/128")
-			_, err := LastUsableIP(*ipnet)
+			_, err := LastUsableIP(types.Pool{
+				IPNet: *ipnet,
+			})
 			Expect(err).To(MatchError(HavePrefix("net mask is too short")))
 		})
 
 		It("throws an error when running LastUsableIP for a /127", func() {
 			_, ipnet, _ := net.ParseCIDR("2000::/127")
-			_, err := LastUsableIP(*ipnet)
+			_, err := LastUsableIP(types.Pool{
+				IPNet: *ipnet,
+			})
 			Expect(err).To(MatchError(HavePrefix("net mask is too short")))
 		})
 
 		It("correctly gets the LastUsableIP for a /126", func() {
 			_, ipnet, _ := net.ParseCIDR("2000::/126")
-			ip, err := LastUsableIP(*ipnet)
+			ip, err := LastUsableIP(types.Pool{
+				IPNet: *ipnet,
+			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ip.To16()).To(Equal(net.ParseIP("2000::2").To16()))
 		})
 
 		It("correctly gets the LastUsableIP for a /64", func() {
 			_, ipnet, _ := net.ParseCIDR("2000::/64")
-			ip, err := LastUsableIP(*ipnet)
+			ip, err := LastUsableIP(types.Pool{
+				IPNet: *ipnet,
+			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ip.To16()).To(Equal(net.ParseIP("2000::ffff:ffff:ffff:fffe").To16()))
 		})
@@ -399,34 +433,46 @@ var _ = Describe("HasUsableIPs operations", func() {
 	Context("small subnets", func() {
 		It("IPv4 /32 has no usable IPs", func() {
 			_, ipnet, _ := net.ParseCIDR("192.168.0.0/32")
-			Expect(HasUsableIPs(*ipnet)).To(BeFalse())
+			Expect(HasUsableIPs(types.Pool{
+				IPNet: *ipnet,
+			})).To(BeFalse())
 		})
 
 		It("IPv4 /31 has no usable IPs", func() {
 			_, ipnet, _ := net.ParseCIDR("192.168.0.0/31")
-			Expect(HasUsableIPs(*ipnet)).To(BeFalse())
+			Expect(HasUsableIPs(types.Pool{
+				IPNet: *ipnet,
+			})).To(BeFalse())
 		})
 
 		It("IPv6 /128 has no usable IPs", func() {
 			_, ipnet, _ := net.ParseCIDR("2000::/128")
-			Expect(HasUsableIPs(*ipnet)).To(BeFalse())
+			Expect(HasUsableIPs(types.Pool{
+				IPNet: *ipnet,
+			})).To(BeFalse())
 		})
 
 		It("IPv6 /127 has no usable IPs", func() {
 			_, ipnet, _ := net.ParseCIDR("2000::/127")
-			Expect(HasUsableIPs(*ipnet)).To(BeFalse())
+			Expect(HasUsableIPs(types.Pool{
+				IPNet: *ipnet,
+			})).To(BeFalse())
 		})
 	})
 
 	Context("larger subnets", func() {
 		It("IPv4 /30 has usable IPs", func() {
 			_, ipnet, _ := net.ParseCIDR("192.168.0.0/30")
-			Expect(HasUsableIPs(*ipnet)).To(BeTrue())
+			Expect(HasUsableIPs(types.Pool{
+				IPNet: *ipnet,
+			})).To(BeTrue())
 		})
 
 		It("IPv6 /126 has usable IPs", func() {
 			_, ipnet, _ := net.ParseCIDR("2000::/126")
-			Expect(HasUsableIPs(*ipnet)).To(BeTrue())
+			Expect(HasUsableIPs(types.Pool{
+				IPNet: *ipnet,
+			})).To(BeTrue())
 		})
 	})
 })
@@ -555,7 +601,9 @@ var _ = Describe("GetIPRange operations", func() {
 	It("creates an IPv4 range properly for 30 bits network address", func() {
 		_, ipnet, err := net.ParseCIDR("192.168.21.100/30")
 		Expect(err).NotTo(HaveOccurred())
-		firstip, lastip, err := GetIPRange(*ipnet, nil, nil)
+		firstip, lastip, err := GetIPRange(types.Pool{
+			IPNet: *ipnet,
+		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(firstip)).To(Equal("192.168.21.101"))
 		Expect(fmt.Sprint(lastip)).To(Equal("192.168.21.102"))
@@ -565,7 +613,10 @@ var _ = Describe("GetIPRange operations", func() {
 		_, ipnet, err := net.ParseCIDR("192.168.2.200/24")
 		Expect(err).NotTo(HaveOccurred())
 		ip := net.ParseIP("192.168.2.23") // range start
-		firstip, lastip, err := GetIPRange(*ipnet, ip, nil)
+		firstip, lastip, err := GetIPRange(types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: ip,
+		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(firstip)).To(Equal("192.168.2.23"))
 		Expect(fmt.Sprint(lastip)).To(Equal("192.168.2.254"))
@@ -574,7 +625,9 @@ var _ = Describe("GetIPRange operations", func() {
 	It("creates an IPv4 range properly for 27 bits network address", func() {
 		_, ipnet, err := net.ParseCIDR("192.168.2.200/27")
 		Expect(err).NotTo(HaveOccurred())
-		firstip, lastip, err := GetIPRange(*ipnet, nil, nil)
+		firstip, lastip, err := GetIPRange(types.Pool{
+			IPNet: *ipnet,
+		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(firstip)).To(Equal("192.168.2.193"))
 		Expect(fmt.Sprint(lastip)).To(Equal("192.168.2.222"))
@@ -583,7 +636,9 @@ var _ = Describe("GetIPRange operations", func() {
 	It("creates an IPv4 range properly for 24 bits network address", func() {
 		_, ipnet, err := net.ParseCIDR("192.168.2.200/24")
 		Expect(err).NotTo(HaveOccurred())
-		firstip, lastip, err := GetIPRange(*ipnet, nil, nil)
+		firstip, lastip, err := GetIPRange(types.Pool{
+			IPNet: *ipnet,
+		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(firstip)).To(Equal("192.168.2.1"))
 		Expect(fmt.Sprint(lastip)).To(Equal("192.168.2.254"))
@@ -593,7 +648,10 @@ var _ = Describe("GetIPRange operations", func() {
 		_, ipnet, err := net.ParseCIDR("192.168.2.200/24")
 		Expect(err).NotTo(HaveOccurred())
 		endRange := net.ParseIP("192.168.2.100")
-		firstip, lastip, err := GetIPRange(*ipnet, nil, endRange)
+		firstip, lastip, err := GetIPRange(types.Pool{
+			IPNet:    *ipnet,
+			RangeEnd: endRange,
+		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(firstip)).To(Equal("192.168.2.1"))
 		Expect(fmt.Sprint(lastip)).To(Equal("192.168.2.100"))
@@ -604,7 +662,11 @@ var _ = Describe("GetIPRange operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 		startRange := net.ParseIP("192.168.2.50")
 		endRange := net.ParseIP("192.168.2.100")
-		firstip, lastip, err := GetIPRange(*ipnet, startRange, endRange)
+		firstip, lastip, err := GetIPRange(types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: startRange,
+			RangeEnd:   endRange,
+		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(firstip)).To(Equal("192.168.2.50"))
 		Expect(fmt.Sprint(lastip)).To(Equal("192.168.2.100"))
@@ -615,7 +677,11 @@ var _ = Describe("GetIPRange operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 		startRange := net.ParseIP("192.168.1.150")
 		endRange := net.ParseIP("192.168.3.100")
-		firstip, lastip, err := GetIPRange(*ipnet, startRange, endRange)
+		firstip, lastip, err := GetIPRange(types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: startRange,
+			RangeEnd:   endRange,
+		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(firstip)).To(Equal("192.168.2.1"))
 		Expect(fmt.Sprint(lastip)).To(Equal("192.168.2.254"))
@@ -626,7 +692,11 @@ var _ = Describe("GetIPRange operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 		startRange := net.ParseIP("192.168.2.100")
 		endRange := net.ParseIP("192.168.2.50")
-		firstip, lastip, err := GetIPRange(*ipnet, startRange, endRange)
+		firstip, lastip, err := GetIPRange(types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: startRange,
+			RangeEnd:   endRange,
+		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(firstip)).To(Equal("192.168.2.100"))
 		Expect(fmt.Sprint(lastip)).To(Equal("192.168.2.254"))
@@ -637,7 +707,11 @@ var _ = Describe("GetIPRange operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 		startRange := net.ParseIP("192.168.2.50")
 		endRange := net.ParseIP("192.168.2.50")
-		firstip, lastip, err := GetIPRange(*ipnet, startRange, endRange)
+		firstip, lastip, err := GetIPRange(types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: startRange,
+			RangeEnd:   endRange,
+		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(firstip)).To(Equal("192.168.2.50"))
 		Expect(fmt.Sprint(lastip)).To(Equal("192.168.2.50"))
@@ -646,7 +720,9 @@ var _ = Describe("GetIPRange operations", func() {
 	It("creates an IPv6 range properly for 116 bits network address", func() {
 		_, ipnet, err := net.ParseCIDR("2001::0/116")
 		Expect(err).NotTo(HaveOccurred())
-		firstip, lastip, err := GetIPRange(*ipnet, nil, nil)
+		firstip, lastip, err := GetIPRange(types.Pool{
+			IPNet: *ipnet,
+		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(firstip)).To(Equal("2001::1"))
 		Expect(fmt.Sprint(lastip)).To(Equal("2001::ffe"))
@@ -655,7 +731,9 @@ var _ = Describe("GetIPRange operations", func() {
 	It("creates an IPv6 range when the first hextet has leading zeroes", func() {
 		_, ipnet, err := net.ParseCIDR("fd:db8:abcd:0012::0/96")
 		Expect(err).NotTo(HaveOccurred())
-		firstip, lastip, err := GetIPRange(*ipnet, nil, nil)
+		firstip, lastip, err := GetIPRange(types.Pool{
+			IPNet: *ipnet,
+		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(firstip)).To(Equal("fd:db8:abcd:12::1"))
 		Expect(fmt.Sprint(lastip)).To(Equal("fd:db8:abcd:12::ffff:fffe"))
@@ -664,7 +742,9 @@ var _ = Describe("GetIPRange operations", func() {
 	It("creates an IPv6 range properly for 96 bits network address", func() {
 		_, ipnet, err := net.ParseCIDR("2001:db8:abcd:0012::0/96")
 		Expect(err).NotTo(HaveOccurred())
-		firstip, lastip, err := GetIPRange(*ipnet, nil, nil)
+		firstip, lastip, err := GetIPRange(types.Pool{
+			IPNet: *ipnet,
+		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(firstip)).To(Equal("2001:db8:abcd:12::1"))
 		Expect(fmt.Sprint(lastip)).To(Equal("2001:db8:abcd:12::ffff:fffe"))
@@ -673,7 +753,9 @@ var _ = Describe("GetIPRange operations", func() {
 	It("creates an IPv6 range properly for 64 bits network address", func() {
 		_, ipnet, err := net.ParseCIDR("2001:db8:abcd:0012::0/64")
 		Expect(err).NotTo(HaveOccurred())
-		firstip, lastip, err := GetIPRange(*ipnet, nil, nil)
+		firstip, lastip, err := GetIPRange(types.Pool{
+			IPNet: *ipnet,
+		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(firstip)).To(Equal("2001:db8:abcd:12::1"))
 		Expect(fmt.Sprint(lastip)).To(Equal("2001:db8:abcd:12:ffff:ffff:ffff:fffe"))
@@ -683,7 +765,10 @@ var _ = Describe("GetIPRange operations", func() {
 		_, ipnet, err := net.ParseCIDR("2001:db8:abcd:0012::0/64")
 		Expect(err).NotTo(HaveOccurred())
 		endRange := net.ParseIP("2001:db8:abcd:0012::100")
-		firstip, lastip, err := GetIPRange(*ipnet, nil, endRange)
+		firstip, lastip, err := GetIPRange(types.Pool{
+			IPNet:    *ipnet,
+			RangeEnd: endRange,
+		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(firstip)).To(Equal("2001:db8:abcd:12::1"))
 		Expect(fmt.Sprint(lastip)).To(Equal("2001:db8:abcd:12::100"))
@@ -694,7 +779,11 @@ var _ = Describe("GetIPRange operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 		startRange := net.ParseIP("2001:db8:abcd:0012::50")
 		endRange := net.ParseIP("2001:db8:abcd:0012::100")
-		firstip, lastip, err := GetIPRange(*ipnet, startRange, endRange)
+		firstip, lastip, err := GetIPRange(types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: startRange,
+			RangeEnd:   endRange,
+		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(firstip)).To(Equal("2001:db8:abcd:12::50"))
 		Expect(fmt.Sprint(lastip)).To(Equal("2001:db8:abcd:12::100"))
@@ -705,7 +794,11 @@ var _ = Describe("GetIPRange operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 		startRange := net.ParseIP("2000:db8:abcd:0012::50")
 		endRange := net.ParseIP("2003:db8:abcd:0012::100")
-		firstip, lastip, err := GetIPRange(*ipnet, startRange, endRange)
+		firstip, lastip, err := GetIPRange(types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: startRange,
+			RangeEnd:   endRange,
+		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(firstip)).To(Equal("2001:db8:abcd:12::1"))
 		Expect(fmt.Sprint(lastip)).To(Equal("2001:db8:abcd:12:ffff:ffff:ffff:fffe"))
@@ -716,7 +809,11 @@ var _ = Describe("GetIPRange operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 		startRange := net.ParseIP("2001:db8:abcd:0012::100")
 		endRange := net.ParseIP("2001:db8:abcd:0012::50")
-		firstip, lastip, err := GetIPRange(*ipnet, startRange, endRange)
+		firstip, lastip, err := GetIPRange(types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: startRange,
+			RangeEnd:   endRange,
+		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(firstip)).To(Equal("2001:db8:abcd:12::100"))
 		Expect(fmt.Sprint(lastip)).To(Equal("2001:db8:abcd:12:ffff:ffff:ffff:fffe"))
@@ -727,7 +824,11 @@ var _ = Describe("GetIPRange operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 		startRange := net.ParseIP("2001:db8:abcd:0012::100")
 		endRange := net.ParseIP("2001:db8:abcd:0012::100")
-		firstip, lastip, err := GetIPRange(*ipnet, startRange, endRange)
+		firstip, lastip, err := GetIPRange(types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: startRange,
+			RangeEnd:   endRange,
+		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(firstip)).To(Equal("2001:db8:abcd:12::100"))
 		Expect(fmt.Sprint(lastip)).To(Equal("2001:db8:abcd:12::100"))
@@ -738,7 +839,11 @@ var _ = Describe("GetIPRange operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 		startRange := net.ParseIP("2001:db8:480:603d:304:403::")
 		endRange := net.ParseIP("2001:db8:480:603d:304:403:0:4")
-		firstip, lastip, err := GetIPRange(*ipnet, startRange, endRange)
+		firstip, lastip, err := GetIPRange(types.Pool{
+			IPNet:      *ipnet,
+			RangeStart: startRange,
+			RangeEnd:   endRange,
+		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fmt.Sprint(firstip)).To(Equal("2001:db8:480:603d:304:403::"))
 		Expect(fmt.Sprint(lastip)).To(Equal("2001:db8:480:603d:304:403:0:4"))
@@ -747,14 +852,18 @@ var _ = Describe("GetIPRange operations", func() {
 	It("do not fail when the mask meets minimum required", func() {
 		_, validIPNet, err := net.ParseCIDR("192.168.21.100/30")
 		Expect(err).NotTo(HaveOccurred())
-		_, _, err = GetIPRange(*validIPNet, nil, nil)
+		_, _, err = GetIPRange(types.Pool{
+			IPNet: *validIPNet,
+		})
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("fails when the mask is too short", func() {
 		_, badIPNet, err := net.ParseCIDR("192.168.21.100/31")
 		Expect(err).NotTo(HaveOccurred())
-		_, _, err = GetIPRange(*badIPNet, nil, nil)
+		_, _, err = GetIPRange(types.Pool{
+			IPNet: *badIPNet,
+		})
 		Expect(err).To(MatchError(HavePrefix("net mask is too short")))
 	})
 })

--- a/pkg/iphelpers/iphelpers_test.go
+++ b/pkg/iphelpers/iphelpers_test.go
@@ -290,6 +290,15 @@ var _ = Describe("FirstUsableIP operations", func() {
 			})
 			Expect(err).To(MatchError(HavePrefix("net mask is too short")))
 		})
+		It("throws an error when running FirstUsableIP for a /32 with includeNetwork options", func() {
+			_, ipnet, _ := net.ParseCIDR("192.168.0.0/32")
+			ip, err := FirstUsableIP(types.Pool{
+				IPNet:                 *ipnet,
+				IncludeNetworkAddress: true,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ip.String()).To(Equal("192.168.0.0"))
+		})
 
 		It("throws an error when running FirstUsableIP for a /31", func() {
 			_, ipnet, _ := net.ParseCIDR("192.168.0.0/31")
@@ -297,6 +306,15 @@ var _ = Describe("FirstUsableIP operations", func() {
 				IPNet: *ipnet,
 			})
 			Expect(err).To(MatchError(HavePrefix("net mask is too short")))
+		})
+		It("throws an error when running FirstUsableIP for a /31 with includeNetwork option", func() {
+			_, ipnet, _ := net.ParseCIDR("192.168.0.0/31")
+			ip, err := FirstUsableIP(types.Pool{
+				IPNet:                 *ipnet,
+				IncludeNetworkAddress: true,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ip.String()).To(Equal("192.168.0.0"))
 		})
 
 		It("correctly gets the FirstUsableIP for a /30", func() {
@@ -373,6 +391,16 @@ var _ = Describe("LastUsableIP operations", func() {
 			Expect(err).To(MatchError(HavePrefix("net mask is too short")))
 		})
 
+		It("throws an error when running LastUsableIP for a /31 with includeBroadcast option", func() {
+			_, ipnet, _ := net.ParseCIDR("192.168.0.0/31")
+			ip, err := LastUsableIP(types.Pool{
+				IPNet:                   *ipnet,
+				IncludeBroadcastAddress: true,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ip.String()).To(Equal("192.168.0.1"))
+		})
+
 		It("correctly gets the LastUsableIP for a /30", func() {
 			_, ipnet, _ := net.ParseCIDR("192.168.0.0/30")
 			ip, err := LastUsableIP(types.Pool{
@@ -437,12 +465,33 @@ var _ = Describe("HasUsableIPs operations", func() {
 				IPNet: *ipnet,
 			})).To(BeFalse())
 		})
-
+		It("IPv4 /32 has no usable IPs with includeNetwork option", func() {
+			_, ipnet, _ := net.ParseCIDR("192.168.0.0/32")
+			Expect(HasUsableIPs(types.Pool{
+				IPNet:                 *ipnet,
+				IncludeNetworkAddress: true,
+			})).To(BeTrue())
+		})
 		It("IPv4 /31 has no usable IPs", func() {
 			_, ipnet, _ := net.ParseCIDR("192.168.0.0/31")
 			Expect(HasUsableIPs(types.Pool{
 				IPNet: *ipnet,
 			})).To(BeFalse())
+		})
+		It("IPv4 /31 has no usable IPs with includeBroadcast option", func() {
+			_, ipnet, _ := net.ParseCIDR("192.168.0.0/31")
+			Expect(HasUsableIPs(types.Pool{
+				IPNet:                 *ipnet,
+				IncludeNetworkAddress: true,
+			})).To(BeTrue())
+		})
+		It("IPv4 /31 has no usable IPs with includeNetwork and includeBroadcast options", func() {
+			_, ipnet, _ := net.ParseCIDR("192.168.0.0/31")
+			Expect(HasUsableIPs(types.Pool{
+				IPNet:                   *ipnet,
+				IncludeNetworkAddress:   true,
+				IncludeBroadcastAddress: true,
+			})).To(BeTrue())
 		})
 
 		It("IPv6 /128 has no usable IPs", func() {

--- a/pkg/iphelpers/iphelpers_test.go
+++ b/pkg/iphelpers/iphelpers_test.go
@@ -478,11 +478,18 @@ var _ = Describe("HasUsableIPs operations", func() {
 				IPNet: *ipnet,
 			})).To(BeFalse())
 		})
-		It("IPv4 /31 has no usable IPs with includeBroadcast option", func() {
+		It("IPv4 /31 has no usable IPs with includeNetwork option", func() {
 			_, ipnet, _ := net.ParseCIDR("192.168.0.0/31")
 			Expect(HasUsableIPs(types.Pool{
 				IPNet:                 *ipnet,
 				IncludeNetworkAddress: true,
+			})).To(BeTrue())
+		})
+		It("IPv4 /31 has no usable IPs with includeBroadcast option", func() {
+			_, ipnet, _ := net.ParseCIDR("192.168.0.0/31")
+			Expect(HasUsableIPs(types.Pool{
+				IPNet:                   *ipnet,
+				IncludeBroadcastAddress: true,
 			})).To(BeTrue())
 		})
 		It("IPv4 /31 has no usable IPs with includeNetwork and includeBroadcast options", func() {

--- a/pkg/storage/kubernetes/ipam.go
+++ b/pkg/storage/kubernetes/ipam.go
@@ -720,10 +720,13 @@ RANGESLOOP:
 			}
 		}
 
-		newips = append(newips, newip)
-		if mode == whereaboutstypes.Allocate && ipamConf.SingleIP && len(newips) > 0 {
-			logging.Debugf("Single IP is allocated from %v pool, stop iterating", ipRange)
-			break
+		if mode == whereaboutstypes.Allocate {
+			newips = append(newips, newip)
+
+			if ipamConf.SingleIP && len(newips) > 0 {
+				logging.Debugf("Single IP is allocated from %v pool, stop iterating", ipRange)
+				break
+			}
 		}
 	}
 	return newips, err

--- a/pkg/storage/kubernetes/ipam.go
+++ b/pkg/storage/kubernetes/ipam.go
@@ -653,7 +653,8 @@ RANGESLOOP:
 			case whereaboutstypes.Allocate:
 				newip, updatedreservelist, err = allocate.AssignIP(ipRange, reservelist, ipam.ContainerID, ipamConf.GetPodRef(), ipam.IfName)
 				if err != nil {
-					if ok := goerr.As(err, new(allocate.AssignmentError)); !ok {
+					ok := goerr.As(err, new(allocate.AssignmentError))
+					if !ok || (ok && !ipamConf.SingleIP) {
 						_ = logging.Errorf("Error assigning IP: %v", err)
 						return newips, err
 					}

--- a/pkg/storage/kubernetes/ipam.go
+++ b/pkg/storage/kubernetes/ipam.go
@@ -621,9 +621,13 @@ RANGESLOOP:
 					return newips, err
 				}
 				ipRange = whereaboutstypes.RangeConfiguration{
-					Range:      ipRange.Range,
-					RangeStart: rangeStart,
-					RangeEnd:   rangeEnd,
+					Range: ipRange.Range,
+
+					RangeStart:            rangeStart,
+					IncludeNetworkAddress: ipRange.IncludeNetworkAddress,
+
+					RangeEnd:                rangeEnd,
+					IncludeBroadcastAddress: ipRange.IncludeBroadcastAddress,
 				}
 			}
 			logging.Debugf("using pool identifier: %v", poolIdentifier)

--- a/pkg/storage/kubernetes/ipam.go
+++ b/pkg/storage/kubernetes/ipam.go
@@ -653,8 +653,7 @@ RANGESLOOP:
 			case whereaboutstypes.Allocate:
 				newip, updatedreservelist, err = allocate.AssignIP(ipRange, reservelist, ipam.ContainerID, ipamConf.GetPodRef(), ipam.IfName)
 				if err != nil {
-					var assignErr *allocate.AssignmentError
-					if ok := goerr.As(err, &assignErr); !ok || (ok && !ipamConf.SingleIP) {
+					if ok := goerr.As(err, new(allocate.AssignmentError)); !ok || (ok && !ipamConf.SingleIP) {
 						_ = logging.Errorf("Error assigning IP: %v", err)
 						return newips, err
 					}

--- a/pkg/storage/kubernetes/ipam.go
+++ b/pkg/storage/kubernetes/ipam.go
@@ -20,6 +20,8 @@ import (
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 
+	"gomodules.xyz/jsonpatch/v2"
+
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/allocate"
 	whereaboutsv1alpha1 "github.com/k8snetworkplumbingwg/whereabouts/pkg/api/whereabouts.cni.cncf.io/v1alpha1"
 	wbclient "github.com/k8snetworkplumbingwg/whereabouts/pkg/generated/clientset/versioned"
@@ -27,7 +29,6 @@ import (
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/logging"
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/storage"
 	whereaboutstypes "github.com/k8snetworkplumbingwg/whereabouts/pkg/types"
-	"gomodules.xyz/jsonpatch/v2"
 )
 
 const UnnamedNetwork string = ""
@@ -708,6 +709,9 @@ func IPManagementKubernetesUpdate(ctx context.Context, mode int, ipam *Kubernete
 		}
 
 		newips = append(newips, newip)
+		if ipamConf.SingleIP {
+			break
+		}
 	}
 	return newips, err
 }

--- a/pkg/storage/kubernetes/ipam.go
+++ b/pkg/storage/kubernetes/ipam.go
@@ -653,7 +653,7 @@ RANGESLOOP:
 			case whereaboutstypes.Allocate:
 				newip, updatedreservelist, err = allocate.AssignIP(ipRange, reservelist, ipam.ContainerID, ipamConf.GetPodRef(), ipam.IfName)
 				if err != nil {
-					assignErr := new(allocate.AssignmentError)
+					var assignErr *allocate.AssignmentError
 					if ok := goerr.As(err, &assignErr); !ok || (ok && !ipamConf.SingleIP) {
 						_ = logging.Errorf("Error assigning IP: %v", err)
 						return newips, err

--- a/pkg/storage/kubernetes/ipam.go
+++ b/pkg/storage/kubernetes/ipam.go
@@ -605,12 +605,12 @@ RANGESLOOP:
 					return newips, err
 				}
 				poolIdentifier.IpRange = nodeSliceRange
-				rangeStart, err := iphelpers.FirstUsableIP(*ipNet)
+				rangeStart, err := iphelpers.FirstUsableIP(*ipNet, ipRange.IncludeNetworkAddress)
 				if err != nil {
 					logging.Errorf("Error parsing node slice cidr to range start: %v", err)
 					return newips, err
 				}
-				rangeEnd, err := iphelpers.LastUsableIP(*ipNet)
+				rangeEnd, err := iphelpers.LastUsableIP(*ipNet, ipRange.IncludeBroadcastAddress)
 				if err != nil {
 					logging.Errorf("Error parsing node slice cidr to range start: %v", err)
 					return newips, err
@@ -676,7 +676,7 @@ RANGESLOOP:
 				if ipforoverlappingrangeupdate == nil {
 					// Do not fail if allocation was not found.
 					logging.Debugf("Failed to find allocation for container ID: %s", ipam.ContainerID)
-					return nil, nil
+					continue RANGESLOOP
 				}
 			}
 
@@ -716,7 +716,7 @@ RANGESLOOP:
 		}
 
 		newips = append(newips, newip)
-		if ipamConf.SingleIP && len(newips) > 0 {
+		if mode == whereaboutstypes.Allocate && ipamConf.SingleIP && len(newips) > 0 {
 			logging.Debugf("Single IP is allocated from %v pool, stop iterating", ipRange)
 			break
 		}

--- a/pkg/storage/kubernetes/ipam.go
+++ b/pkg/storage/kubernetes/ipam.go
@@ -653,7 +653,7 @@ RANGESLOOP:
 			case whereaboutstypes.Allocate:
 				newip, updatedreservelist, err = allocate.AssignIP(ipRange, reservelist, ipam.ContainerID, ipamConf.GetPodRef(), ipam.IfName)
 				if err != nil {
-					if ok := goerr.As(err, new(allocate.AssignmentError)); !ipamConf.SingleIP || !ok {
+					if ok := goerr.As(err, new(allocate.AssignmentError)); !ok {
 						_ = logging.Errorf("Error assigning IP: %v", err)
 						return newips, err
 					}

--- a/pkg/storage/kubernetes/ipam.go
+++ b/pkg/storage/kubernetes/ipam.go
@@ -653,8 +653,8 @@ RANGESLOOP:
 			case whereaboutstypes.Allocate:
 				newip, updatedreservelist, err = allocate.AssignIP(ipRange, reservelist, ipam.ContainerID, ipamConf.GetPodRef(), ipam.IfName)
 				if err != nil {
-					ok := goerr.As(err, new(allocate.AssignmentError))
-					if !ok || (ok && !ipamConf.SingleIP) {
+					assignErr := new(allocate.AssignmentError)
+					if ok := goerr.As(err, &assignErr); !ok || (ok && !ipamConf.SingleIP) {
 						_ = logging.Errorf("Error assigning IP: %v", err)
 						return newips, err
 					}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -2,9 +2,10 @@ package storage
 
 import (
 	"context"
-	"github.com/k8snetworkplumbingwg/whereabouts/pkg/api/whereabouts.cni.cncf.io/v1alpha1"
 	"net"
 	"time"
+
+	"github.com/k8snetworkplumbingwg/whereabouts/pkg/api/whereabouts.cni.cncf.io/v1alpha1"
 
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/types"
 )
@@ -35,7 +36,7 @@ type Store interface {
 // OverlappingRangeStore is an interface for wrapping overlappingrange storage options
 type OverlappingRangeStore interface {
 	GetOverlappingRangeIPReservation(ctx context.Context, ip net.IP, podRef, networkName string) (*v1alpha1.OverlappingRangeIPReservation, error)
-	UpdateOverlappingRangeAllocation(ctx context.Context, mode int, ip net.IP, podRef, ifName, networkName string) error
+	UpdateOverlappingRangeAllocation(ctx context.Context, mode types.OperationType, ip net.IP, podRef, ifName, networkName string) error
 }
 
 type Temporary interface {

--- a/pkg/types/pool.go
+++ b/pkg/types/pool.go
@@ -1,0 +1,15 @@
+package types
+
+import (
+	"net"
+)
+
+type Pool struct {
+	IPNet net.IPNet
+
+	RangeStart            net.IP
+	IncludeNetworkAddress bool
+
+	RangeEnd                net.IP
+	IncludeBroadcastAddress bool
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -43,6 +43,9 @@ type RangeConfiguration struct {
 	Range      string   `json:"range"`
 	RangeStart net.IP   `json:"range_start,omitempty"`
 	RangeEnd   net.IP   `json:"range_end,omitempty"`
+
+	IncludeNetworkAddress   bool `json:"include_network_address,omitempty"`
+	IncludeBroadcastAddress bool `json:"include_broadcast_address,omitempty"`
 }
 
 // IPAMConfig describes the expected json configuration for this plugin
@@ -59,6 +62,8 @@ type IPAMConfig struct {
 	NodeSliceSize            string               `json:"node_slice_size"`
 	RangeStart               net.IP               `json:"range_start,omitempty"`
 	RangeEnd                 net.IP               `json:"range_end,omitempty"`
+	IncludeNetworkAddress    bool                 `json:"include_network_address,omitempty"`
+	IncludeBroadcastAddress  bool                 `json:"include_broadcast_address,omitempty"`
 	GatewayStr               string               `json:"gateway"`
 	LeaderLeaseDuration      int                  `json:"leader_lease_duration,omitempty"`
 	LeaderRenewDeadline      int                  `json:"leader_renew_deadline,omitempty"`
@@ -91,6 +96,8 @@ func (ic *IPAMConfig) UnmarshalJSON(data []byte) error {
 		Range                    string               `json:"range"`
 		RangeStart               string               `json:"range_start,omitempty"`
 		RangeEnd                 string               `json:"range_end,omitempty"`
+		IncludeNetworkAddress    bool                 `json:"include_network_address,omitempty"`
+		IncludeBroadcastAddress  bool                 `json:"include_broadcast_address,omitempty"`
 		GatewayStr               string               `json:"gateway"`
 		EtcdHost                 string               `json:"etcd_host,omitempty"`
 		EtcdUsername             string               `json:"etcd_username,omitempty"`
@@ -134,6 +141,8 @@ func (ic *IPAMConfig) UnmarshalJSON(data []byte) error {
 		Range:                    ipamConfigAlias.Range,
 		RangeStart:               backwardsCompatibleIPAddress(ipamConfigAlias.RangeStart),
 		RangeEnd:                 backwardsCompatibleIPAddress(ipamConfigAlias.RangeEnd),
+		IncludeNetworkAddress:    ipamConfigAlias.IncludeNetworkAddress,
+		IncludeBroadcastAddress:  ipamConfigAlias.IncludeBroadcastAddress,
 		NodeSliceSize:            ipamConfigAlias.NodeSliceSize,
 		GatewayStr:               ipamConfigAlias.GatewayStr,
 		LeaderLeaseDuration:      ipamConfigAlias.LeaderLeaseDuration,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -215,8 +215,9 @@ func (ir IPReservation) String() string {
 type OperationType int
 
 const (
+	_ OperationType = iota
 	// Allocate operation identifier
-	Allocate OperationType = 0
+	Allocate
 	// Deallocate operation identifier
 	Deallocate = 1
 )

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -52,6 +52,7 @@ type IPAMConfig struct {
 	Routes                   []*cnitypes.Route    `json:"routes"`
 	Addresses                []Address            `json:"addresses,omitempty"`
 	IPRanges                 []RangeConfiguration `json:"ipRanges"`
+	SingleIP                 bool                 `json:"singleIP,omitempty"`
 	OmitRanges               []string             `json:"exclude,omitempty"`
 	DNS                      cnitypes.DNS         `json:"dns"`
 	Range                    string               `json:"range"`

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -52,7 +52,7 @@ type IPAMConfig struct {
 	Routes                   []*cnitypes.Route    `json:"routes"`
 	Addresses                []Address            `json:"addresses,omitempty"`
 	IPRanges                 []RangeConfiguration `json:"ipRanges"`
-	SingleIP                 bool                 `json:"singleIP,omitempty"`
+	SingleIP                 bool                 `json:"singleIP"`
 	OmitRanges               []string             `json:"exclude,omitempty"`
 	DNS                      cnitypes.DNS         `json:"dns"`
 	Range                    string               `json:"range"`
@@ -84,6 +84,7 @@ func (ic *IPAMConfig) UnmarshalJSON(data []byte) error {
 		Datastore                string               `json:"datastore"`
 		Addresses                []Address            `json:"addresses,omitempty"`
 		IPRanges                 []RangeConfiguration `json:"ipRanges"`
+		SingleIP                 bool                 `json:"singleIP,omitempty"`
 		NodeSliceSize            string               `json:"node_slice_size"`
 		OmitRanges               []string             `json:"exclude,omitempty"`
 		DNS                      cnitypes.DNS         `json:"dns"`
@@ -127,6 +128,7 @@ func (ic *IPAMConfig) UnmarshalJSON(data []byte) error {
 		Routes:                   ipamConfigAlias.Routes,
 		Addresses:                ipamConfigAlias.Addresses,
 		IPRanges:                 ipamConfigAlias.IPRanges,
+		SingleIP:                 ipamConfigAlias.SingleIP,
 		OmitRanges:               ipamConfigAlias.OmitRanges,
 		DNS:                      ipamConfigAlias.DNS,
 		Range:                    ipamConfigAlias.Range,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -219,7 +219,7 @@ const (
 	// Allocate operation identifier
 	Allocate
 	// Deallocate operation identifier
-	Deallocate = 1
+	Deallocate
 )
 
 var ErrNoIPRanges = errors.New("no IP ranges in whereabouts config")

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -212,9 +212,11 @@ func (ir IPReservation) String() string {
 	return fmt.Sprintf("IP: %s is reserved for pod: %s", ir.IP.String(), ir.PodRef)
 }
 
+type OperationType int
+
 const (
 	// Allocate operation identifier
-	Allocate = 0
+	Allocate OperationType = 0
 	// Deallocate operation identifier
 	Deallocate = 1
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

A feature of single-IP allocation (from a list of provided IP pools/ranges) is introduced. Such a feature allows to configure as many IP pools as we want and have only one IP assigned from whichever pool with spare "capacity".

In addition to, for cases when address pools are just parts of some larger network, split into a list of smaller networks, it's possible to include the first (network) and the last (broadcast) addresses of a CIDR to the allocatable range.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single‑IP mode and options to include network/broadcast addresses in IPAM ranges.
  * Improved support for multiple IP pools, dual‑stack and named‑range scenarios.

* **Refactor**
  * Introduced a unified Pool abstraction for IP range handling.
  * Standardized operation‑type semantics for allocation/deallocation and richer per‑range controls.

* **Tests**
  * Expanded end‑to‑end and unit test coverage for pool, single‑IP and multi‑pool behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->