### PR TITLE
fix token-watcher script

### DIFF
--- a/script/lib.sh
+++ b/script/lib.sh
@@ -12,7 +12,6 @@ WHEREABOUTS_KUBECONFIG_LITERAL=$(echo "$WHEREABOUTS_KUBECONFIG" | sed -e s'|/hos
 
 SERVICE_ACCOUNT_PATH=/var/run/secrets/kubernetes.io/serviceaccount
 KUBE_CA_FILE=${KUBE_CA_FILE:-$SERVICE_ACCOUNT_PATH/ca.crt}
-SERVICE_ACCOUNT_TOKEN=$(cat $SERVICE_ACCOUNT_PATH/token)
 SERVICE_ACCOUNT_TOKEN_PATH=$SERVICE_ACCOUNT_PATH/token
 SKIP_TLS_VERIFY=${SKIP_TLS_VERIFY:-false}
 
@@ -35,7 +34,8 @@ function warn()
 
 function generateKubeConfig {
   # Check if we're running as a k8s pod.
-if [ -f "$SERVICE_ACCOUNT_PATH/token" ]; then
+if [ -f "$SERVICE_ACCOUNT_TOKEN_PATH" ]; then
+  SERVICE_ACCOUNT_TOKEN=$(cat $SERVICE_ACCOUNT_TOKEN_PATH)
   # We're running as a k8d pod - expect some variables.
   if [ -z ${KUBERNETES_SERVICE_HOST} ]; then
     error "KUBERNETES_SERVICE_HOST not set"; exit 1;

--- a/script/token-watcher.sh
+++ b/script/token-watcher.sh
@@ -10,12 +10,12 @@ while true; do
   # Check the md5sum of the service account token and ca.
   svcaccountsum="$(get_token_md5sum)"
   casum="$(get_ca_file_md5sum)"
-  if [ "$svcaccountsum" != "$LAST_SERVICEACCOUNT_MD5SUM" ] || ! [ "$SKIP_TLS_VERIFY" == "true" ] && [ "$casum" != "$LAST_KUBE_CA_FILE_MD5SUM" ]; then
+  if [ "$svcaccountsum" != "$LAST_SERVICEACCOUNT_MD5SUM" ] || ([ "$SKIP_TLS_VERIFY" != "true" ] && [ "$casum" != "$LAST_KUBE_CA_FILE_MD5SUM" ]); then
     log "Detected service account or CA file change, regenerating kubeconfig..."
     generateKubeConfig
     LAST_SERVICEACCOUNT_MD5SUM="$svcaccountsum"
     LAST_KUBE_CA_FILE_MD5SUM="$casum"
   fi
 
-  sleep 1s
+  sleep 1
 done


### PR DESCRIPTION
**What this PR does / why we need it**:
It fixes multiple bug in the token-watcher.sh script so that it can properly run.

* fix the condition to refresh the kubeconfig ( it would only do it if both the SA and CA changed )
* use a more standard argument for the sleep command

**Which issue(s) this PR fixes** :
Fixes #660 



