### PR TITLE
Add `pick_addresses` option for explicit IP candidate selection

### DIFF
--- a/pkg/storage/kubernetes/ipam.go
+++ b/pkg/storage/kubernetes/ipam.go
@@ -612,10 +612,13 @@ func IPManagementKubernetesUpdate(ctx context.Context, mode int, ipam *Kubernete
 					logging.Errorf("Error parsing node slice cidr to range start: %v", err)
 					return newips, err
 				}
+				// Preserve additional range configuration (e.g., omit ranges, pick addresses) while overriding start/end
 				ipRange = whereaboutstypes.RangeConfiguration{
-					Range:      ipRange.Range,
-					RangeStart: rangeStart,
-					RangeEnd:   rangeEnd,
+					OmitRanges:    ipRange.OmitRanges,
+					Range:         ipRange.Range,
+					RangeStart:    rangeStart,
+					RangeEnd:      rangeEnd,
+					PickAddresses: ipRange.PickAddresses,
 				}
 			}
 			logging.Debugf("using pool identifier: %v", poolIdentifier)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -39,10 +39,11 @@ type NetConfList struct {
 }
 
 type RangeConfiguration struct {
-	OmitRanges []string `json:"exclude,omitempty"`
-	Range      string   `json:"range"`
-	RangeStart net.IP   `json:"range_start,omitempty"`
-	RangeEnd   net.IP   `json:"range_end,omitempty"`
+	OmitRanges    []string `json:"exclude,omitempty"`
+	Range         string   `json:"range"`
+	RangeStart    net.IP   `json:"range_start,omitempty"`
+	RangeEnd      net.IP   `json:"range_end,omitempty"`
+	PickAddresses []net.IP `json:"pick_addresses,omitempty"`
 }
 
 // IPAMConfig describes the expected json configuration for this plugin


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->

**What this PR does / why we need it**:

In some environments, only a specific subset of IPs within a subnet are available for allocation — due to external infrastructure constraints, policy grouping, or operational lifecycle (e.g., IPs rotating in and out of service). The existing range_start/range_end mechanism requires contiguous ranges, which cannot express arbitrary sets of eligible addresses.

The new `pick_addresses` field in RangeConfiguration allows users to specify an explicit list of candidate IPs. When provided, allocation selects from this list (in order) instead of iterating the full range, while still honoring CIDR bounds, exclude ranges, and existing reservations.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Also fixes IPManagementKubernetesUpdate to preserve OmitRanges and PickAddresses when reconstructing range configuration for node slicing, where these fields were previously silently dropped.

**Special notes for your reviewer** *(optional)*:

