### PR TITLE
Move IP reconciler scheduler to a standalone Deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ FROM alpine:3.23.4
 LABEL org.opencontainers.image.source=https://github.com/k8snetworkplumbingwg/whereabouts
 COPY --from=0 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/whereabouts .
 COPY --from=0 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/ip-control-loop .
+COPY --from=0 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/ip-reconciler .
 COPY --from=0 /go/src/github.com/k8snetworkplumbingwg/whereabouts/bin/node-slice-controller .
 COPY script/install-cni.sh .
 COPY script/lib.sh .

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ git clone https://github.com/k8snetworkplumbingwg/whereabouts && cd whereabouts
 kubectl apply \
     -f doc/crds/daemonset-install.yaml \
     -f doc/crds/whereabouts.cni.cncf.io_ippools.yaml \
-    -f doc/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
+    -f doc/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml \
+    -f doc/crds/reconciler-deployment.yaml
 ```
 
 The daemonset installation requires Kubernetes Version 1.16 or later.

--- a/cmd/controlloop/controlloop.go
+++ b/cmd/controlloop/controlloop.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"time"
+	"syscall"
 
-	"github.com/fsnotify/fsnotify"
-	"github.com/go-co-op/gocron/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -23,21 +21,16 @@ import (
 	wbclient "github.com/k8snetworkplumbingwg/whereabouts/pkg/generated/clientset/versioned"
 	wbinformers "github.com/k8snetworkplumbingwg/whereabouts/pkg/generated/informers/externalversions"
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/logging"
-	"github.com/k8snetworkplumbingwg/whereabouts/pkg/reconciler"
 )
 
 const (
-	allNamespaces               = ""
-	controllerName              = "pod-ip-controlloop"
-	reconcilerCronConfiguration = "/cron-schedule/config"
+	allNamespaces  = ""
+	controllerName = "pod-ip-controlloop"
 )
 
 const (
 	_ int = iota
 	couldNotCreateController
-	cronSchedulerCreationError
-	fileWatcherError
-	couldNotCreateConfigWatcherError
 )
 
 const (
@@ -46,16 +39,15 @@ const (
 
 func main() {
 	logLevel := flag.String("log-level", defaultLogLevel, "Specify the pod controller application logging level")
-	if logLevel != nil && logging.GetLoggingLevel().String() != *logLevel {
+	flag.Parse()
+	if logging.GetLoggingLevel().String() != *logLevel {
 		logging.SetLogLevel(*logLevel)
 	}
 	logging.SetLogStderr(true)
 
 	stopChan := make(chan struct{})
-	errorChan := make(chan error)
 	defer close(stopChan)
-	defer close(errorChan)
-	handleSignals(stopChan, os.Interrupt)
+	handleSignals(stopChan, os.Interrupt, syscall.SIGTERM)
 
 	networkController, err := newPodController(stopChan)
 	if err != nil {
@@ -66,53 +58,8 @@ func main() {
 	networkController.Start(stopChan)
 	defer networkController.Shutdown()
 
-	s, err := gocron.NewScheduler(gocron.WithLocation(time.UTC))
-	if err != nil {
-		os.Exit(cronSchedulerCreationError)
-	}
-
-	watcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		_ = logging.Errorf("error creating configuration watcher: %v", err)
-		os.Exit(fileWatcherError)
-	}
-	defer watcher.Close()
-
-	reconcilerConfigWatcher, err := reconciler.NewConfigWatcher(
-		reconcilerCronConfiguration,
-		s,
-		watcher,
-		func() {
-			reconciler.ReconcileIPs(errorChan)
-		},
-	)
-	if err != nil {
-		os.Exit(couldNotCreateConfigWatcherError)
-	}
-	s.Start()
-
-	const reconcilerConfigMntFile = "/cron-schedule/..data"
-	p := func(e fsnotify.Event) bool {
-		return e.Name == reconcilerConfigMntFile && e.Op&fsnotify.Create == fsnotify.Create
-	}
-	reconcilerConfigWatcher.SyncConfiguration(p)
-
-	for {
-		select {
-		case <-stopChan:
-			logging.Verbosef("shutting down network controller")
-			if err := s.Shutdown(); err != nil {
-				_ = logging.Errorf("error shutting : %v", err)
-			}
-			return
-		case err := <-errorChan:
-			if err == nil {
-				logging.Verbosef("reconciler success")
-			} else {
-				logging.Verbosef("reconciler failure: %s", err)
-			}
-		}
-	}
+	<-stopChan
+	logging.Verbosef("shutting down network controller")
 }
 
 func handleSignals(stopChannel chan struct{}, signals ...os.Signal) {

--- a/cmd/reconciler/main.go
+++ b/cmd/reconciler/main.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/go-co-op/gocron/v2"
+
+	"github.com/k8snetworkplumbingwg/whereabouts/pkg/logging"
+	"github.com/k8snetworkplumbingwg/whereabouts/pkg/reconciler"
+)
+
+const (
+	reconcilerCronConfiguration = "/cron-schedule/config"
+)
+
+const (
+	_ int = iota
+	cronSchedulerCreationError
+	fileWatcherError
+	couldNotCreateConfigWatcherError
+)
+
+const defaultLogLevel = "debug"
+
+func main() {
+	os.Exit(run())
+}
+
+func run() int {
+	logLevel := flag.String("log-level", defaultLogLevel, "Specify the reconciler application logging level")
+	flag.Parse()
+	if logLevel != nil && logging.GetLoggingLevel().String() != *logLevel {
+		logging.SetLogLevel(*logLevel)
+	}
+	logging.SetLogStderr(true)
+
+	stopChan := make(chan struct{})
+	errorChan := make(chan error, 1)
+	defer close(stopChan)
+	defer close(errorChan)
+	handleSignals(stopChan, os.Interrupt, syscall.SIGTERM)
+
+	s, err := gocron.NewScheduler(gocron.WithLocation(time.UTC))
+	if err != nil {
+		return cronSchedulerCreationError
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		_ = logging.Errorf("error creating configuration watcher: %v", err)
+		return fileWatcherError
+	}
+	defer watcher.Close()
+
+	reconcilerConfigWatcher, err := reconciler.NewConfigWatcher(
+		reconcilerCronConfiguration,
+		s,
+		watcher,
+		func() {
+			reconciler.ReconcileIPs(errorChan)
+		},
+	)
+	if err != nil {
+		return couldNotCreateConfigWatcherError
+	}
+	s.Start()
+
+	const reconcilerConfigMntFile = "/cron-schedule/..data"
+	p := func(e fsnotify.Event) bool {
+		return e.Name == reconcilerConfigMntFile && e.Op&fsnotify.Create == fsnotify.Create
+	}
+	reconcilerConfigWatcher.SyncConfiguration(p)
+
+	for {
+		select {
+		case <-stopChan:
+			logging.Verbosef("shutting down reconciler")
+			if err := s.Shutdown(); err != nil {
+				_ = logging.Errorf("error shutting down scheduler: %v", err)
+			}
+			return 0
+		case err := <-errorChan:
+			if err == nil {
+				logging.Verbosef("reconciler run succeeded")
+			} else {
+				logging.Verbosef("reconciler run failed: %s", err)
+			}
+		}
+	}
+}
+
+func handleSignals(stopChannel chan struct{}, signals ...os.Signal) {
+	signalChannel := make(chan os.Signal, 1)
+	signal.Notify(signalChannel, signals...)
+	go func() {
+		<-signalChannel
+		stopChannel <- struct{}{}
+	}()
+}

--- a/deployment/whereabouts-chart/templates/daemonset.yaml
+++ b/deployment/whereabouts-chart/templates/daemonset.yaml
@@ -64,8 +64,6 @@ spec:
             mountPath: /host/opt/cni/bin
           - name: cni-net-dir
             mountPath: /host/etc/cni/net.d
-          - name: cron-scheduler-configmap
-            mountPath: /cron-schedule
       volumes:
         - name: cnibin
           hostPath:
@@ -73,13 +71,6 @@ spec:
         - name: cni-net-dir
           hostPath:
             path: {{ .Values.cniConf.confDir }}
-        - name: cron-scheduler-configmap
-          configMap:
-            name: {{ include "whereabouts.fullname" . }}-config
-            defaultMode: 0744
-            items:
-            - key: "cron-expression"
-              path: "config"
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deployment/whereabouts-chart/templates/reconciler.yaml
+++ b/deployment/whereabouts-chart/templates/reconciler.yaml
@@ -1,0 +1,56 @@
+# Don't forget to update doc/crds/reconciler-deployment.yaml as well
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "whereabouts.fullname" . }}-reconciler
+  {{- include "whereabouts.namespace" . | nindent 2 }}
+  labels:
+    {{- include "whereabouts.labels" . | nindent 4 }}
+spec:
+  # replicas must not be set to more than 1; there is no leader election, so running multiple replicas would cause duplicate reconciliation.
+  replicas: 1
+  selector:
+    matchLabels:
+      name: {{ include "whereabouts.fullname" . }}-reconciler
+      {{- include "whereabouts.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        name: {{ include "whereabouts.fullname" . }}-reconciler
+        {{- include "whereabouts.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "whereabouts.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: reconciler
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: [ "/ip-reconciler" ]
+          args:
+            - -log-level
+            - {{ .Values.reconciler.logLevel }}
+          env:
+          - name: WHEREABOUTS_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          resources:
+            {{- toYaml .Values.reconciler.resources | nindent 12 }}
+          volumeMounts:
+          - name: cron-scheduler-configmap
+            mountPath: /cron-schedule
+      volumes:
+        - name: cron-scheduler-configmap
+          configMap:
+            name: {{ include "whereabouts.fullname" . }}-config
+            defaultMode: 0744
+            items:
+            - key: "cron-expression"
+              path: "config"

--- a/deployment/whereabouts-chart/values.yaml
+++ b/deployment/whereabouts-chart/values.yaml
@@ -58,3 +58,13 @@ cniConf:
 nodeSliceController:
   enabled: true
   priorityClassName: ""
+
+reconciler:
+  logLevel: debug
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "50Mi"
+    limits:
+      cpu: "100m"
+      memory: "50Mi"

--- a/doc/crds/daemonset-install.yaml
+++ b/doc/crds/daemonset-install.yaml
@@ -148,8 +148,6 @@ spec:
           mountPath: /host/opt/cni/bin
         - name: cni-net-dir
           mountPath: /host/etc/cni/net.d
-        - name: cron-scheduler-configmap
-          mountPath: /cron-schedule
       volumes:
         - name: cnibin
           hostPath:
@@ -157,10 +155,3 @@ spec:
         - name: cni-net-dir
           hostPath:
             path: /etc/cni/net.d
-        - name: cron-scheduler-configmap
-          configMap:
-            name: "whereabouts-config"
-            defaultMode: 0744
-            items:
-            - key: "cron-expression"
-              path: "config"

--- a/doc/crds/reconciler-deployment.yaml
+++ b/doc/crds/reconciler-deployment.yaml
@@ -1,0 +1,53 @@
+# Don't forget to update deployment/whereabouts-chart/templates/reconciler.yaml as well
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: whereabouts-reconciler
+  namespace: kube-system
+  labels:
+    tier: node
+    app: whereabouts-reconciler
+spec:
+  # replicas must not be set to more than 1; there is no leader election, so running multiple replicas would cause duplicate reconciliation.
+  replicas: 1
+  selector:
+    matchLabels:
+      name: whereabouts-reconciler
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: whereabouts-reconciler
+        name: whereabouts-reconciler
+    spec:
+      serviceAccountName: whereabouts
+      containers:
+      - name: whereabouts-reconciler
+        command: [ "/ip-reconciler" ]
+        args:
+          - -log-level
+          - debug
+        image: ghcr.io/k8snetworkplumbingwg/whereabouts:latest
+        env:
+        - name: WHEREABOUTS_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+          limits:
+            cpu: "100m"
+            memory: "50Mi"
+        volumeMounts:
+        - name: cron-scheduler-configmap
+          mountPath: /cron-schedule
+      volumes:
+      - name: cron-scheduler-configmap
+        configMap:
+          name: whereabouts-config
+          defaultMode: 0744
+          items:
+          - key: "cron-expression"
+            path: "config"

--- a/e2e/client/deployment.go
+++ b/e2e/client/deployment.go
@@ -1,0 +1,26 @@
+package client
+
+import (
+	"context"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+)
+
+// WaitForDeploymentAvailable polls up to timeout seconds for the given Deployment to have
+// at least one available replica. Returns an error if the condition is never met.
+func WaitForDeploymentAvailable(ctx context.Context, cs *kubernetes.Clientset, namespace, name string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, time.Second, timeout, true, isDeploymentAvailable(ctx, cs, namespace, name))
+}
+
+func isDeploymentAvailable(ctx context.Context, cs *kubernetes.Clientset, namespace, name string) wait.ConditionWithContextFunc {
+	return func(context.Context) (bool, error) {
+		deployment, err := cs.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return deployment.Status.AvailableReplicas > 0, nil
+	}
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -890,6 +890,46 @@ var _ = Describe("Whereabouts functionality", func() {
 		})
 
 	})
+
+	Context("Reconciler conformance", func() {
+		const (
+			reconcilerDeploymentName = "whereabouts-reconciler"
+			reconcilerNamespace      = "kube-system"
+			reconcilerReadyTimeout   = 60 * time.Second
+		)
+
+		var clientInfo *wbtestclient.ClientInfo
+
+		BeforeEach(func() {
+			config, err := util.ClusterConfig()
+			Expect(err).NotTo(HaveOccurred())
+
+			clientInfo, err = wbtestclient.NewClientInfo(config)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("verifies that the whereabouts-reconciler deployment is available", func() {
+			By("waiting for the whereabouts-reconciler deployment to have an available replica")
+			Expect(wbtestclient.WaitForDeploymentAvailable(
+				context.TODO(),
+				clientInfo.Client,
+				reconcilerNamespace,
+				reconcilerDeploymentName,
+				reconcilerReadyTimeout,
+			)).To(Succeed())
+
+			By("verifying the whereabouts-reconciler pod is running")
+			podList, err := wbtestclient.ListPods(
+				context.TODO(),
+				clientInfo.Client,
+				reconcilerNamespace,
+				"app=whereabouts-reconciler",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(podList.Items).NotTo(BeEmpty(), "expected at least one whereabouts-reconciler pod")
+			Expect(podList.Items[0].Status.Phase).To(Equal(core.PodRunning))
+		})
+	})
 })
 
 func verifyNoAllocationsForPodRef(clientInfo *wbtestclient.ClientInfo, ipv4TestRange, testNamespace, podName string, secondaryIfaceIPs []string) {

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -46,5 +46,6 @@ GLDFLAGS="${GLDFLAGS} ${VERSION_LDFLAGS}"
 
 CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} ${GO} build ${GOFLAGS} -ldflags "${GLDFLAGS}" -o bin/${cmd} ./cmd/
 CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} ${GO} build ${GOFLAGS} -ldflags "${GLDFLAGS}" -o bin/ip-control-loop ./cmd/controlloop/
+CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} ${GO} build ${GOFLAGS} -ldflags "${GLDFLAGS}" -o bin/ip-reconciler ./cmd/reconciler/
 CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} ${GO} build ${GOFLAGS} -ldflags "${GLDFLAGS}" -o bin/node-slice-controller ./cmd/nodeslicecontroller/
 

--- a/hack/e2e-setup-kind-cluster.sh
+++ b/hack/e2e-setup-kind-cluster.sh
@@ -98,7 +98,7 @@ trap "rm /tmp/whereabouts-img.tar || true" EXIT
 kind load image-archive --name "$KIND_CLUSTER_NAME" /tmp/whereabouts-img.tar
 
 echo "## install whereabouts"
-for file in "daemonset-install.yaml" "whereabouts.cni.cncf.io_ippools.yaml" "whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml" "whereabouts.cni.cncf.io_nodeslicepools.yaml"; do
+for file in "daemonset-install.yaml" "whereabouts.cni.cncf.io_ippools.yaml" "whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml" "whereabouts.cni.cncf.io_nodeslicepools.yaml" "reconciler-deployment.yaml"; do
   # insert 'imagePullPolicy: Never' under the container 'image' so it is certain that the image used
   # by the daemonset is the one loaded into KinD and not one pulled from a repo
   sed '/        image:/a\        imagePullPolicy: Never' "$ROOT/doc/crds/$file" | retry kubectl apply -f -
@@ -107,4 +107,5 @@ done
 sed '/          image:/a\          imagePullPolicy: Never' "$ROOT/doc/crds/node-slice-controller.yaml" | retry kubectl apply -f -
 retry kubectl wait -n kube-system --for=condition=ready -l app=whereabouts pod --timeout=$TIMEOUT_K8
 retry kubectl wait -n kube-system --for=condition=ready -l app=whereabouts-controller pod --timeout=$TIMEOUT_K8
+retry kubectl wait -n kube-system --for=condition=ready -l app=whereabouts-reconciler pod --timeout=$TIMEOUT_K8
 echo "## done"


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently daemonSet runs both pod controller and the gocron scheduler in the same process. The scheduler only needs to run once per cluster, not once per node, which causes OOM in large clusters. Instead we extract the scheduler into its own binary and Deployment. As such, after this change, the daemonSet will run the pod controller only.

**Which issue(s) this PR fixes** 
Fixes #386

**Special notes for your reviewer** _(optional):_
This is alternative approach/solution to https://github.com/k8snetworkplumbingwg/whereabouts/pull/672 as suggested in https://github.com/k8snetworkplumbingwg/whereabouts/pull/672#issuecomment-4250975691.

