### PR TITLE
install-cni: persist NODENAME for on-host CNI invocations

### DIFF
--- a/script/install-cni.sh
+++ b/script/install-cni.sh
@@ -25,6 +25,10 @@ export LAST_KUBE_CA_FILE_MD5SUM="$(get_ca_file_md5sum)"
 generateWhereaboutsConf
 # ---------------- End generate a whereabouts conf
 
+# ----------------- Persist node name for on-host CNI invocations
+generateNodeNameFile
+# ---------------- End persist node name
+
 
 # copy whereabouts to the cni bin dir
 cp -f /whereabouts $CNI_BIN_DIR

--- a/script/lib.sh
+++ b/script/lib.sh
@@ -92,11 +92,19 @@ fi
 
 function generateWhereaboutsConf {
 
+  # configuration_path is the directory where whereabouts looks up the
+  # optional `nodename` file when resolving the current node's identity
+  # (see getNodeName in pkg/storage/kubernetes/ipam.go). We strip the
+  # leading /host so the path is correct from the on-host CNI invocation.
+  local WHEREABOUTS_CONF_DIR_LITERAL
+  WHEREABOUTS_CONF_DIR_LITERAL=$(dirname "$WHEREABOUTS_KUBECONFIG_LITERAL")
+
   touch $WHEREABOUTS_CONF_FILE
   chmod ${KUBECONFIG_MODE:-600} $WHEREABOUTS_CONF_FILE
   cat > $WHEREABOUTS_CONF_FILE <<EOF
 {
   "datastore": "kubernetes",
+  "configuration_path": "${WHEREABOUTS_CONF_DIR_LITERAL}",
   "kubernetes": {
     "kubeconfig": "${WHEREABOUTS_KUBECONFIG_LITERAL}"
   },
@@ -104,6 +112,26 @@ function generateWhereaboutsConf {
 }
 EOF
 
+}
+
+function generateNodeNameFile {
+
+  # Persist the Kubernetes node name (typically an FQDN) into a file the
+  # on-host whereabouts binary can read. Without this, getNodeName falls
+  # back to /etc/hostname, which on many distributions is the short
+  # hostname and does not match the name the kube-apiserver assigns to
+  # NodeSlicePool allocations -- which makes the on-node binary fail
+  # node-slice lookups with "no allocated node slice for node".
+  if [ -z "${NODENAME:-}" ]; then
+    warn "NODENAME not set; skipping nodename file generation"
+    return
+  fi
+
+  local WHEREABOUTS_NODENAME_FILE
+  WHEREABOUTS_NODENAME_FILE="$CNI_CONF_DIR/whereabouts.d/nodename"
+
+  printf '%s' "$NODENAME" > "$WHEREABOUTS_NODENAME_FILE"
+  chmod ${KUBECONFIG_MODE:-600} "$WHEREABOUTS_NODENAME_FILE"
 }
 
 function get_token_md5sum {

--- a/script/lib.sh
+++ b/script/lib.sh
@@ -97,7 +97,7 @@ function generateWhereaboutsConf {
   # (see getNodeName in pkg/storage/kubernetes/ipam.go). We strip the
   # leading /host so the path is correct from the on-host CNI invocation.
   local WHEREABOUTS_CONF_DIR_LITERAL
-  WHEREABOUTS_CONF_DIR_LITERAL=$(dirname "$WHEREABOUTS_KUBECONFIG_LITERAL")
+  WHEREABOUTS_CONF_DIR_LITERAL="${WHEREABOUTS_KUBECONFIG_LITERAL%/*}"
 
   touch $WHEREABOUTS_CONF_FILE
   chmod ${KUBECONFIG_MODE:-600} $WHEREABOUTS_CONF_FILE


### PR DESCRIPTION
**What this PR does / why we need it**:

When kubelet exec's the on-host whereabouts binary, getNodeName() in pkg/storage/kubernetes/ipam.go tries, in order:

  1. $NODENAME env var
  2. ${configuration_path}/nodename file
  3. /etc/hostname

The binary does not inherit the daemonset pod's NODENAME, and the nodename file is never written. So on setups where /etc/hostname is the short name but the apiserver registers nodes by FQDN (RHEL/CentOS-style, kubeadm with --hostname-override, etc.), the binary reports the short name while node-slice allocations are stored under the FQDN.

Every pod creation against a NAD with node_slice_size then fails:

  [error] error finding node within node slice allocations
  [error] Failed to create leader elector: no allocated node slice for node
  panic: runtime error: invalid memory address or nil pointer dereference

Fix it at the source: have install-cni.sh write $NODENAME (fed via the downward API) to ${CNI_CONF_DIR}/whereabouts.d/nodename, and emit configuration_path in the generated whereabouts.conf so the on-node binary actually consults that directory.