### PR TITLE
node-controller: skip non-whereabouts NADs in multi-NAD check

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,7 +41,7 @@ func LoadIPAMConfig(bytes []byte, envArgs string, extraConfigPaths ...string) (*
 	}
 
 	if n.IPAM == nil {
-		return nil, "", fmt.Errorf("IPAM config missing 'ipam' key")
+		return nil, "", NewMissingIPAMConfigError()
 	} else if !isNetworkRelevant(n.IPAM) {
 		return nil, "", NewInvalidPluginError(n.IPAM.Type)
 	}
@@ -357,6 +357,16 @@ func loadPluginConfig(bytes []byte) (*cnitypes.NetConf, error) {
 func isNetworkRelevant(ipamConfig *types.IPAMConfig) bool {
 	const relevantIPAMType = "whereabouts"
 	return ipamConfig.Type == relevantIPAMType
+}
+
+type MissingIPAMConfigError struct{}
+
+func NewMissingIPAMConfigError() *MissingIPAMConfigError {
+	return &MissingIPAMConfigError{}
+}
+
+func (e *MissingIPAMConfigError) Error() string {
+	return "IPAM config missing 'ipam' key"
 }
 
 type InvalidPluginError struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	nativeerrors "errors"
 	"fmt"
 	"net"
 	"os"
@@ -213,6 +214,19 @@ var _ = Describe("Allocation operations", func() {
 
 		_, _, err := LoadIPAMConfig([]byte(conf), "")
 		Expect(err).To(MatchError(&InvalidPluginError{ipamType: wrongPluginType}))
+	})
+
+	It("throws a typed error when passed a config with no IPAM", func() {
+		conf := `{
+      "cniVersion": "0.3.1",
+      "name": "mynet",
+      "type": "bridge"
+      }`
+
+		_, _, err := LoadIPAMConfig([]byte(conf), "")
+		var missingIPAMConfigErr *MissingIPAMConfigError
+		Expect(nativeerrors.As(err, &missingIPAMConfigErr)).To(BeTrue())
+		Expect(err).To(MatchError("IPAM config missing 'ipam' key"))
 	})
 
 	It("allows for leading zeroes in the range in start/end range format", func() {

--- a/pkg/node-controller/controller.go
+++ b/pkg/node-controller/controller.go
@@ -338,6 +338,10 @@ func (c *Controller) syncHandler(ctx context.Context, key string) error {
 	//nad does exist so did it change node_slice_range or slice_size
 	ipamConf, err := ipamConfiguration(nad, "")
 	if err != nil {
+		if isNotWhereaboutsIPAMConfig(err) {
+			logger.V(4).Info("skipping non-whereabouts net-attach-def", "error", err)
+			return nil
+		}
 		return err
 	}
 
@@ -507,6 +511,10 @@ func (c *Controller) checkForMultiNadMismatch(name, namespace string) error {
 	}
 	ipamConf, err := ipamConfiguration(nad, "")
 	if err != nil {
+		if isNotWhereaboutsIPAMConfig(err) {
+			klog.V(4).Infof("skipping net-attach-def %s/%s in multi-NAD check: %s", namespace, name, err.Error())
+			return nil
+		}
 		return err
 	}
 
@@ -564,6 +572,12 @@ func getSliceName(ipamConf *types.IPAMConfig) string {
 		sliceName = ipamConf.NetworkName
 	}
 	return sliceName
+}
+
+func isNotWhereaboutsIPAMConfig(err error) bool {
+	var invalidPluginErr *config.InvalidPluginError
+	var missingIPAMConfigErr *config.MissingIPAMConfigError
+	return nativeerrors.As(err, &invalidPluginErr) || nativeerrors.As(err, &missingIPAMConfigErr)
 }
 
 // since multiple nads can share a nodeslicepool we need to set multiple owner refs but only

--- a/pkg/node-controller/controller.go
+++ b/pkg/node-controller/controller.go
@@ -522,7 +522,13 @@ func (c *Controller) checkForMultiNadMismatch(name, namespace string) error {
 	for _, additionalNad := range nadList {
 		additionalIpamConf, err := ipamConfiguration(additionalNad, "")
 		if err != nil {
-			return err
+			// Other net-attach-defs in the cluster may use a different IPAM
+			// (e.g. host-local, static) or be meta-only with no `ipam` key.
+			// Such NADs are irrelevant to whereabouts node-slice reconciliation
+			// and must not block sync of valid whereabouts NADs.
+			klog.V(4).Infof("skipping net-attach-def %s/%s in multi-NAD check: %s",
+				additionalNad.Namespace, additionalNad.Name, err.Error())
+			continue
 		}
 
 		if len(additionalIpamConf.IPRanges) == 0 {

--- a/pkg/node-controller/controller_test.go
+++ b/pkg/node-controller/controller_test.go
@@ -116,6 +116,52 @@ func newNad(name string, networkName string, networkRange string, sliceSize stri
 	}
 }
 
+func newHostLocalNad(name string) *k8snetplumbersv1.NetworkAttachmentDefinition {
+	return &k8snetplumbersv1.NetworkAttachmentDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: k8snetplumbersv1.SchemeGroupVersion.String(),
+			Kind:       "NetworkAttachmentDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: k8snetplumbersv1.NetworkAttachmentDefinitionSpec{
+			Config: `
+				{
+					"cniVersion": "0.3.1",
+					"name": "host-local-test",
+					"type": "macvlan",
+					"ipam": {
+						"type": "host-local",
+						"subnet": "10.0.0.0/24"
+					}
+				}`,
+		},
+	}
+}
+
+func newNoIPAMNad(name string) *k8snetplumbersv1.NetworkAttachmentDefinition {
+	return &k8snetplumbersv1.NetworkAttachmentDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: k8snetplumbersv1.SchemeGroupVersion.String(),
+			Kind:       "NetworkAttachmentDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: k8snetplumbersv1.NetworkAttachmentDefinitionSpec{
+			Config: `
+				{
+					"cniVersion": "0.3.1",
+					"name": "no-ipam-test",
+					"type": "bridge"
+				}`,
+		},
+	}
+}
+
 func getOwnerRefs(nads []*k8snetplumbersv1.NetworkAttachmentDefinition) []metav1.OwnerReference {
 	if len(nads) == 1 {
 		return []metav1.OwnerReference{
@@ -448,6 +494,26 @@ func TestCreatesNodeSlicePoolsWithNodes(t *testing.T) {
 	f.kubeobjects = append(f.kubeobjects, node1, node2)
 	f.nadObjects = append(f.nadObjects, nad)
 	f.expectNodeSlicePoolCreateAction(nodeSlicePool)
+
+	f.run(context.TODO(), getKey(nad, t))
+}
+
+func TestSkipsHostLocalNAD(t *testing.T) {
+	f := newFixture(t)
+	nad := newHostLocalNad("host-local-test")
+
+	f.nadLister = append(f.nadLister, nad)
+	f.nadObjects = append(f.nadObjects, nad)
+
+	f.run(context.TODO(), getKey(nad, t))
+}
+
+func TestSkipsNADWithoutIPAM(t *testing.T) {
+	f := newFixture(t)
+	nad := newNoIPAMNad("no-ipam-test")
+
+	f.nadLister = append(f.nadLister, nad)
+	f.nadObjects = append(f.nadObjects, nad)
 
 	f.run(context.TODO(), getKey(nad, t))
 }


### PR DESCRIPTION
I recently played with node slices, and noticed this edge-case:

**What this PR does / why we need it**:

`checkForMultiNadMismatch` iterates over every NetworkAttachmentDefinition in the cluster and calls ipamConfiguration on each. For NADs whose IPAM type is not whereabouts (or that have no ipam section at all), LoadIPAMConfig returns an error that propagates all the way up to syncHandler.

The result: a single host-local (or other non-whereabouts) NAD anywhere in the cluster blocks reconciliation of every whereabouts NAD. No NodeSlicePool ever gets created, and on-node CNI calls for NADs with node_slice_size set then panic when looking up the missing slice.

Skip these NADs with a debug log instead. They cannot collide with whereabouts on whereabouts-specific state, so failing the whole reconciliation over them is not useful.