### PR TITLE
test: retry StatefulSet scale conflicts in E2E

### DIFF
--- a/e2e/client/whereabouts.go
+++ b/e2e/client/whereabouts.go
@@ -207,7 +207,11 @@ func (c *ClientInfo) ScaleStatefulSet(statefulSetName string, namespace string, 
 		if err != nil {
 			return err
 		}
-		newReplicas := *statefulSet.Spec.Replicas + int32(deltaInstance)
+		replicas := int32(1)
+		if statefulSet.Spec.Replicas != nil {
+			replicas = *statefulSet.Spec.Replicas
+		}
+		newReplicas := replicas + int32(deltaInstance)
 		statefulSet.Spec.Replicas = &newReplicas
 
 		_, err = c.Client.AppsV1().StatefulSets(namespace).Update(ctx, statefulSet, metav1.UpdateOptions{})

--- a/e2e/client/whereabouts.go
+++ b/e2e/client/whereabouts.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
 
 	nettypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	netclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
@@ -200,17 +201,18 @@ func (c *ClientInfo) DeleteStatefulSet(namespace string, serviceName string, lab
 }
 
 func (c *ClientInfo) ScaleStatefulSet(statefulSetName string, namespace string, deltaInstance int) error {
-	statefulSet, err := c.Client.AppsV1().StatefulSets(namespace).Get(context.TODO(), statefulSetName, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-	newReplicas := *statefulSet.Spec.Replicas + int32(deltaInstance)
-	statefulSet.Spec.Replicas = &newReplicas
+	ctx := context.Background()
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		statefulSet, err := c.Client.AppsV1().StatefulSets(namespace).Get(ctx, statefulSetName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		newReplicas := *statefulSet.Spec.Replicas + int32(deltaInstance)
+		statefulSet.Spec.Replicas = &newReplicas
 
-	if _, err := c.Client.AppsV1().StatefulSets(namespace).Update(context.TODO(), statefulSet, metav1.UpdateOptions{}); err != nil {
+		_, err = c.Client.AppsV1().StatefulSets(namespace).Update(ctx, statefulSet, metav1.UpdateOptions{})
 		return err
-	}
-	return nil
+	})
 }
 
 func deleteRightNowAndBlockUntilAssociatedPodsAreGone() metav1.DeleteOptions {


### PR DESCRIPTION
## Summary
- retry StatefulSet scale updates on Kubernetes resource-version conflicts
- re-fetch the latest StatefulSet before each retry
- addresses flaky E2E failures like Dependabot PR #715 hitting a 409 while scaling statefulset web

## Testing
- GOCACHE=/private/tmp/whereabouts-go-build-cache go test ./e2e/client ./e2e/entities ./e2e/util
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved StatefulSet scaling reliability by automatically retrying updates when concurrent changes cause conflicts.
  - Scaling now works correctly when the replica count is not explicitly set, using one replica as the default before applying adjustments.
  - Reduces failed scaling operations and helps maintain the intended instance count during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->