### PR TITLE
fix: Missing priorityClass configuration on IP Reconciler

### DIFF
--- a/deployment/whereabouts-chart/templates/reconciler.yaml
+++ b/deployment/whereabouts-chart/templates/reconciler.yaml
@@ -23,6 +23,9 @@ spec:
         name: {{ include "whereabouts.fullname" . }}-reconciler
         {{- include "whereabouts.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       serviceAccountName: {{ include "whereabouts.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/deployment/whereabouts-chart/templates/reconciler.yaml
+++ b/deployment/whereabouts-chart/templates/reconciler.yaml
@@ -23,7 +23,7 @@ spec:
         name: {{ include "whereabouts.fullname" . }}-reconciler
         {{- include "whereabouts.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.priorityClassName }}
+      {{- with .Values.reconciler.priorityClassName | default .Values.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
       serviceAccountName: {{ include "whereabouts.serviceAccountName" . }}

--- a/deployment/whereabouts-chart/values.yaml
+++ b/deployment/whereabouts-chart/values.yaml
@@ -61,6 +61,7 @@ nodeSliceController:
 
 reconciler:
   logLevel: debug
+  priorityClassName: ""
   resources:
     requests:
       cpu: "100m"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #719 

**Special notes for your reviewer** *(optional)*:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reconciler pods can now be assigned a custom priority class to influence scheduling behavior.
  * Reconciler-specific priority settings take precedence, while a general priority class remains available as a fallback.
  * The new configuration option is included in the default deployment settings and can be customized as needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->