### PR TITLE
config: guard empty plugin list in LoadIPAMConfiguration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -318,6 +318,9 @@ func LoadIPAMConfiguration(bytes []byte, envArgs string, extraConfigPaths ...str
 			return nil, err
 		}
 
+		if len(pluginConfigList.Plugins) == 0 {
+			return nil, fmt.Errorf("NetworkAttachmentDefinition config list contains no plugins")
+		}
 		pluginConfigList.Plugins[0].CNIVersion = pluginConfig.CNIVersion
 		firstPluginBytes, err := json.Marshal(pluginConfigList.Plugins[0])
 		if err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -443,3 +443,16 @@ func generateIPAMConfWithoutOverlappingRanges() string {
 		}
 	}`
 }
+
+var _ = Describe("LoadIPAMConfiguration with an empty plugin list", func() {
+	It("returns an error instead of panicking when the plugins list is empty, null, or missing", func() {
+		for _, conf := range []string{
+			`{"cniVersion":"0.3.1","name":"test","plugins":[]}`,
+			`{"cniVersion":"0.3.1","name":"test","plugins":null}`,
+			`{"cniVersion":"0.3.1","name":"test"}`,
+		} {
+			_, err := LoadIPAMConfiguration([]byte(conf), "")
+			Expect(err).To(HaveOccurred())
+		}
+	})
+})


### PR DESCRIPTION
`LoadIPAMConfiguration` handles the CNI config-list case by indexing `pluginConfigList.Plugins[0]` without checking the list length (pkg/config/config.go). A NetworkAttachmentDefinition whose config has an empty `plugins` array, an explicit `plugins: null`, or an omitted `plugins` key unmarshals to a zero-length slice, so `Plugins[0]` panics with `index out of range [0] with length 0`.

Both the node controller and the control loop pass `nad.Spec.Config` straight into this path, so a namespaced user who can create a NetworkAttachmentDefinition can crash the controller with a malformed config.

This returns a clear error when the plugin list is empty instead of indexing into it. Adds a regression test (Ginkgo) covering the empty-array, null, and omitted-key cases. Without the guard the test panics with the index-out-of-range above; with it, the `pkg/config` suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration validation when no network plugins are specified.
  * Returns a clear error instead of failing unexpectedly for empty, null, or missing plugin lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->