### PR TITLE
Fix reconciler cron ConfigMap reload race on first projection

### DIFF
--- a/cmd/reconciler/main.go
+++ b/cmd/reconciler/main.go
@@ -70,11 +70,9 @@ func run() int {
 	}
 	s.Start()
 
-	const reconcilerConfigMntFile = "/cron-schedule/..data"
-	p := func(e fsnotify.Event) bool {
-		return e.Name == reconcilerConfigMntFile && e.Op&fsnotify.Create == fsnotify.Create
-	}
-	reconcilerConfigWatcher.SyncConfiguration(p)
+	reconcilerConfigWatcher.SyncConfiguration(
+		reconciler.ReconcilerConfigEventPredicate(reconcilerCronConfiguration),
+	)
 
 	for {
 		select {

--- a/pkg/reconciler/config.go
+++ b/pkg/reconciler/config.go
@@ -69,13 +69,30 @@ func newConfigWatcher(
 	}, nil
 }
 
+// ReconcilerConfigEventPredicate matches fsnotify events that mean the
+// reconciler cron config may have changed:
+//   - CREATE on "..data": ConfigMap atomic writer swapped the projected payload
+//     (repeat updates when the key was already present)
+//   - CREATE on configPath: first-time projection of the key; kubelet creates
+//     this symlink *after* swapping "..data", so watching "..data" alone can
+//     race, read before the symlink exists, and miss the update
+func ReconcilerConfigEventPredicate(configPath string) func(fsnotify.Event) bool {
+	dataDirFile := filepath.Join(filepath.Dir(configPath), "..data")
+	return func(event fsnotify.Event) bool {
+		if event.Op&fsnotify.Create != fsnotify.Create {
+			return false
+		}
+		return event.Name == dataDirFile || event.Name == configPath
+	}
+}
+
 func determineCronExpression(configPath string) (string, error) {
 	// We read the expression from a file if present, otherwise we use ReconcilerCronExpression
 	fileContents, err := os.ReadFile(configPath)
 	if err != nil {
-		flatipam, _, err := config.GetFlatIPAM(true, &types.IPAMConfig{}, "")
-		if err != nil {
-			return "", logging.Errorf("could not get flatipam config: %v", err)
+		flatipam, _, flatErr := config.GetFlatIPAM(true, &types.IPAMConfig{}, "")
+		if flatErr != nil {
+			return "", logging.Errorf("could not get flatipam config: %v", flatErr)
 		}
 
 		logging.Verbosef("notice: could not read file: %v, defaulting to expression from configuration: %v", err, flatipam.IPAM.ReconcilerCronExpression)
@@ -107,6 +124,7 @@ func (c *ConfigWatcher) syncConfig(relevantEventPredicate func(event fsnotify.Ev
 			updatedSchedule, err := determineCronExpression(c.configPath)
 			if err != nil {
 				_ = logging.Errorf("error determining cron expression from %q: %v", c.configPath, err)
+				continue
 			}
 			logging.Verbosef(
 				"configuration updated to file %q. New cron expression: %s",
@@ -125,6 +143,7 @@ func (c *ConfigWatcher) syncConfig(relevantEventPredicate func(event fsnotify.Ev
 			)
 			if err != nil {
 				_ = logging.Errorf("error updating job %q configuration: %v", c.job.ID().String(), err)
+				continue
 			}
 			c.currentSchedule = updatedSchedule
 			logging.Verbosef(

--- a/pkg/reconciler/config_test.go
+++ b/pkg/reconciler/config_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	"github.com/fsnotify/fsnotify"
@@ -69,6 +70,153 @@ var _ = Describe("Reconciler configuration watcher", func() {
 			Eventually(func() string { return config.currentSchedule }).Should(Equal(updatedCronWithSeconds))
 			Eventually(mailbox).WithTimeout(time.Minute).Should(Receive())
 		})
+	})
+})
+
+var _ = Describe("ReconcilerConfigEventPredicate", func() {
+	const configPath = "/cron-schedule/config"
+	var predicate func(fsnotify.Event) bool
+
+	BeforeEach(func() {
+		predicate = ReconcilerConfigEventPredicate(configPath)
+	})
+
+	table.DescribeTable("event relevance",
+		func(event fsnotify.Event, expected bool) {
+			Expect(predicate(event)).To(Equal(expected))
+		},
+		table.Entry("CREATE on ..data (ConfigMap atomic swap)", fsnotify.Event{
+			Name: "/cron-schedule/..data",
+			Op:   fsnotify.Create,
+		}, true),
+		table.Entry("CREATE on config file (first-time projection)", fsnotify.Event{
+			Name: configPath,
+			Op:   fsnotify.Create,
+		}, true),
+		table.Entry("CREATE on unrelated path", fsnotify.Event{
+			Name: "/cron-schedule/..data_tmp",
+			Op:   fsnotify.Create,
+		}, false),
+		table.Entry("WRITE on ..data", fsnotify.Event{
+			Name: "/cron-schedule/..data",
+			Op:   fsnotify.Write,
+		}, false),
+		table.Entry("WRITE on config file", fsnotify.Event{
+			Name: configPath,
+			Op:   fsnotify.Write,
+		}, false),
+		table.Entry("REMOVE on config file", fsnotify.Event{
+			Name: configPath,
+			Op:   fsnotify.Remove,
+		}, false),
+	)
+})
+
+var _ = Describe("ConfigMap first-projection race", func() {
+	// Reproduces kubelet's optional ConfigMap mount sequence:
+	// CREATE ..data (payload ready) before the user-visible config symlink exists.
+	// Watching only ..data races: the read of config fails and the later CREATE
+	// on config was previously ignored, leaving the default schedule stuck.
+	const (
+		initialCron = "30 4 * * *"
+		updatedCron = "* * * * *"
+	)
+
+	var (
+		config     *ConfigWatcher
+		mountDir   string
+		configPath string
+		scheduler  gocron.Scheduler
+		watcher    *fsnotify.Watcher
+	)
+
+	BeforeEach(func() {
+		var err error
+		mountDir, err = os.MkdirTemp("", "cron-schedule")
+		Expect(err).NotTo(HaveOccurred())
+		configPath = filepath.Join(mountDir, "config")
+
+		// Start with the flatfile/default schedule already in place so
+		// NewConfigWatcher succeeds (same expression the race falls back to).
+		Expect(os.WriteFile(configPath, []byte(initialCron), 0o644)).To(Succeed())
+
+		scheduler, err = gocron.NewScheduler()
+		Expect(err).NotTo(HaveOccurred())
+		watcher, err = fsnotify.NewWatcher()
+		Expect(err).NotTo(HaveOccurred())
+
+		config, err = newConfigWatcher(
+			configPath,
+			scheduler,
+			watcher,
+			func(schedule string) gocron.JobDefinition {
+				return gocron.CronJob(schedule, false)
+			},
+			func() {},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(config.currentSchedule).To(Equal(initialCron))
+		scheduler.Start()
+	})
+
+	AfterEach(func() {
+		_ = scheduler.Shutdown()
+		_ = watcher.Close()
+		_ = os.RemoveAll(mountDir)
+	})
+
+	simulateKubeletFirstProjection := func() {
+		timestampedDir := filepath.Join(mountDir, "..2026_01_01_00_00_00.1")
+		Expect(os.Mkdir(timestampedDir, 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(timestampedDir, "config"), []byte(updatedCron), 0o644)).To(Succeed())
+
+		// Drop the previous regular file so configPath is missing when ..data appears.
+		Expect(os.Remove(configPath)).To(Succeed())
+
+		// 1) atomic writer swaps ..data while config symlink does not exist yet
+		Expect(os.Symlink(filepath.Base(timestampedDir), filepath.Join(mountDir, "..data"))).To(Succeed())
+
+		// Wait until the watcher has observed ..data *before* the config symlink
+		// exists. Without a flatfile the read fails and the schedule is unchanged;
+		// that is the race window the fix must recover from.
+		Consistently(func() string { return config.currentSchedule }).
+			WithTimeout(300 * time.Millisecond).
+			WithPolling(50 * time.Millisecond).
+			Should(Equal(initialCron))
+		Expect(configPath).NotTo(BeAnExistingFile())
+
+		// 2) kubelet then creates the user-visible config symlink
+		Expect(os.Symlink(filepath.Join("..data", "config"), configPath)).To(Succeed())
+	}
+
+	It("updates the schedule when ..data is created before the config symlink", func() {
+		config.SyncConfiguration(ReconcilerConfigEventPredicate(configPath))
+		// Allow the watcher goroutine to subscribe before emitting filesystem events.
+		time.Sleep(100 * time.Millisecond)
+
+		simulateKubeletFirstProjection()
+
+		Eventually(func() string { return config.currentSchedule }).
+			WithTimeout(5 * time.Second).
+			WithPolling(50 * time.Millisecond).
+			Should(Equal(updatedCron))
+	})
+
+	It("never adopts the new schedule when only ..data CREATE is watched (pre-fix)", func() {
+		dataDirFile := filepath.Join(mountDir, "..data")
+		config.SyncConfiguration(func(event fsnotify.Event) bool {
+			return event.Name == dataDirFile && event.Op&fsnotify.Create == fsnotify.Create
+		})
+		time.Sleep(100 * time.Millisecond)
+
+		simulateKubeletFirstProjection()
+
+		// ..data CREATE races ahead of the config symlink; the later CREATE on
+		// config is ignored, so the updated expression is never applied.
+		Consistently(func() string { return config.currentSchedule }).
+			WithTimeout(2 * time.Second).
+			WithPolling(50 * time.Millisecond).
+			Should(Equal(initialCron))
 	})
 })
 


### PR DESCRIPTION
## What this PR does / why we need it:
Fixes a race where the IP reconciler cron schedule ConfigMap (`whereabouts-config`) is mounted successfully, but some reconciler pods keep using the default schedule (`30 4 * * *`) until the pod is restarted.

## Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged): 

Special notes for your reviewer (optional):

## Root cause

Kubernetes ConfigMap projection updates the mount roughly as:

1. write a new timestamped directory
2. atomically swap the `..data` symlink
3. create/update the user-visible `config` symlink (`config` → `..data/config`)

The watcher previously treated only `CREATE` on `/cron-schedule/..data` as relevant, then immediately read `/cron-schedule/config`.

On **first-time** ConfigMap projection, kubelet can emit `CREATE` on `..data` **before** the `config` symlink exists. In that case:

1. `ReadFile("/cron-schedule/config")` fails
2. the code falls back to the flatfile default (`30 4 * * *`)
3. schedule compares equal to the current value → `no changes in schedule, nothing to do`
4. the later `CREATE /cron-schedule/config` event is ignored as `event not relevant`
5. the pod stays stuck on the default cron until restart

This matches the failure logs:

```text
could not read file: <nil>, using expression from flatfile: 30 4 * * *
configuration updated to file "/cron-schedule/..data". New cron expression: 30 4 * * *
no changes in schedule, nothing to do.
event not relevant: CREATE "/cron-schedule/config"
```

(`could not read file: <nil>` was also caused by shadowing the original `ReadFile` error with a successful `GetFlatIPAM` result; that logging issue is fixed in this PR.)

## Solution

- Add `ReconcilerConfigEventPredicate` that treats `CREATE` on both:
  - `..data` (repeat ConfigMap updates via atomic swap)
  - the projected config file path (first-time key projection)
- Use that helper from `cmd/reconciler`
- Fix the shadowed `err` in `determineCronExpression` so the real read failure is logged
- Add unit tests covering both relevant and irrelevant fsnotify events

No sleep/retry path: matching the first-time `config` CREATE is enough and avoids extra latency.

## Testing

### Unit tests
```bash
go test ./pkg/reconciler/ -count=1
```
Passed locally.

### Manual reproduction on OpenShift (37-node cluster)

Cluster: **OCP 4.18.42**, OVN-Kubernetes, **37** `whereabouts-reconciler` pods (DaemonSet).

Steps:
1. Deployed Whereabouts via CNO `whereabouts-shim` additional network so the reconciler DaemonSet was running.
2. Created the schedule ConfigMap as documented:
   ```bash
   oc create configmap whereabouts-config -n openshift-multus \
     --from-literal=reconciler_cron_expression="* * * * *"
   ```
3. Checked all reconciler pods for whether they adopted `* * * * *`.

Result after settle:
| Outcome | Count |
|---|---|
| Updated successfully to `* * * * *` | **28 / 37** |
| Stuck on default `30 4 * * *` (bug) | **9 / 37** |

On affected pods, `/cron-schedule/config` already contained `* * * * *`, but the process still used `30 4 * * *` and logged the race signature above. Deleting/recreating an affected pod picked up the ConfigMap correctly (startup read path).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved configuration synchronization when projected configuration data or the configured file is created.
* Prevented unrelated file changes and removals from triggering unnecessary synchronization.
* Improved handling of configuration and scheduling errors to avoid applying invalid updates.
* Improved fallback configuration error reporting.

## Tests

* Added coverage for configuration event filtering and optional configuration mount scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->