### PR TITLE
docs: propose persistent VM IPs via IPAMClaim

### DIFF
--- a/doc/proposals/persistent-ips-ipamclaims.md
+++ b/doc/proposals/persistent-ips-ipamclaims.md
@@ -132,27 +132,41 @@ interface.
 currently inject `NSE.IPAMClaimReference` into delegate IPAM CNI stdin. Production
 wiring keeps the claim on the pod annotation. Whereabouts therefore:
 
-1. Accepts `ipam-claim-reference` from CNI config when present (IPAM section,
-   top-level net field, or `args.cni`) — useful for tests and future Multus
-   injection. A present-but-invalid value here **fails immediately**, it does
-   not fall through to the annotation.
-2. If the attribute is still **absent**, **resolves the claim from the pod's
-   network-selection annotation** via the Kubernetes API:
-   - When both interface name and network name are available, match **both**.
-   - A single-field match (interface **or** network) is allowed only when it
-     yields **exactly one** candidate.
-   - Ambiguous matches (the same network attached more than once, or multiple
-     NSEs that satisfy a single-field filter) **fail CNI ADD**. Do not pick an
-     arbitrary NSE.
+Collect every present `ipam-claim-reference` from these sources, in this
+**precedence** (highest first):
 
-`ipam-claim-reference` is a **claim name only**. Fail closed:
+1. IPAM section of the CNI config
+2. Top-level net field
+3. `args.cni` (tests / future Multus injection)
+4. Pod network-selection annotation (production path today — Multus does not
+   inject `NSE.IPAMClaimReference` into delegate IPAM stdin)
 
-- **Absent** (the attribute is not set on any resolved source): legacy
-  pod-scoped allocation.
-- **Present but invalid** (empty string, whitespace-only, non-string, `ns/name`,
-  or any other malformed value): **return a validation error**. Do **not** fall
-  back to pod-scoped allocation. A typo must not silently lose persistence on
-  pod DEL.
+Resolution rules, applied **before any pool or status write**, and used by ADD,
+DEL, and reconcile whenever they read a claim name from CNI/pod (after ADD, the
+reservation identity is authoritative — see below):
+
+- A present-but-invalid value in **any** source (empty string, whitespace-only,
+  non-string, `ns/name`, or other malformed) **fails immediately**. It does not
+  fall through to a lower source.
+- If two or more sources are present with **valid but different** claim names,
+  **reject** the operation. Do not pick a winner. ADD and a later DEL/reconcile
+  must not bind different claims.
+- If sources agree, or only one source is present and valid, use that name.
+- If the attribute is **absent** from every source, use legacy pod-scoped
+  allocation.
+
+Annotation matching (source 4), when that source is used:
+
+- When both interface name and network name are available, match **both**.
+- A single-field match (interface **or** network) is allowed only when it
+  yields **exactly one** candidate.
+- Ambiguous matches (the same network attached more than once, or multiple
+  NSEs that satisfy a single-field filter) **fail CNI ADD**. Do not pick an
+  arbitrary NSE.
+
+`ipam-claim-reference` is a **claim name only**. Tests must cover every source
+combination: each source alone, agreeing sources, conflicting valid names, and
+present-but-invalid values mixed with a valid lower source.
 
 ### Claim namespace
 
@@ -163,8 +177,9 @@ This matches `ipam-extensions` (the claim is owned by the VM in the same
 namespace as the `virt-launcher` pod) and avoids a pod in namespace A pinning
 allocations owned by a claim in namespace B.
 
-Reservations still record `namespace/name` because `IPPool` objects live in the
-Whereabouts namespace, not the pod namespace.
+Reservations record the claim as `namespace/name` **plus UID** because `IPPool`
+objects live in the Whereabouts namespace, not the pod namespace, and a deleted
+claim can be recreated with the same name.
 
 ### Keeping the CRs in sync
 
@@ -185,56 +200,74 @@ the claim still exists.
 **Reuse (CNI ADD with populated `status.ips`):** after the `IPAMClaimSpec`
 network/interface check above, also validate address family and pool membership.
 Atomically take over each address only if it is free or already owned by **this**
-claim (match on `IPAMClaimRef`, `namespace/name`). Resource-version conflicts
+claim (match on `IPAMClaimRef` + `IPAMClaimUID`). Resource-version conflicts
 retry. Never steal an IP owned by a different live claim.
 
 **Reconcile (level-driven, not only delete events):** periodically, and on
-informer resync / claim add-update-delete, walk claim-tagged pool and overlapping
-rows and compare them to live `IPAMClaim` objects:
+informer resync / claim add-update-delete, walk the **union** of (1) live
+`IPAMClaim` objects and their `status.ips`, (2) claim-tagged `IPPool` rows, and
+(3) overlapping-range reservations. Starting from reservations alone cannot see
+a live claim whose `status.ips` has no pool row. Starting from claims alone
+cannot see overlap-only leftovers.
 
-- Claim **NotFound** → free the pool row **and** the overlapping CR.
-- Claim **lookup error** (timeout, conflict, unavailable) → **retry do not
+- Claim **NotFound** for a tagged pool or overlapping row → free that row.
+- Claim **lookup error** (timeout, conflict, unavailable) → **retry, do not
   release**.
-- Claim exists, IP is in `status.ips`, pool row missing or untagged → re-reserve
-  if free or already owned by this claim otherwise set a claim condition and do
-  not steal.
-- Claim exists, pool row tagged for this claim, IP **not** in `status.ips` →
-  treat as incomplete persist write the IP into `status.ips` rather than free.
+- Live claim, IP in `status.ips`, pool row missing or untagged → re-reserve
+  if free or already owned by this claim (UID match), otherwise set a claim
+  condition and do not steal.
+- Live claim, pool row tagged for this claim (UID match), IP **not** in
+  `status.ips` → treat as incomplete persist, write the IP into `status.ips`
+  rather than free.
 - Overlapping CR vs pool row: compare the **complete lease identity** — IP,
-  `IPAMClaimRef`, `PodRef`, `IfName`, and the pool/network key. If the overlapping
-  row is missing **or** any of those fields diverge while the pool row is
-  claim-owned, create/update the overlapping CR to match the pool row. A matching
-  `PodRef` with a wrong IP, `IPAMClaimRef`, or `IfName` is still drift and must
-  be repaired. Never leave overlapping state that would reject a later take-over.
+  `IPAMClaimRef`, `IPAMClaimUID`, `PodRef`, `IfName`, and the pool/network key.
+  If the overlapping row is missing **or** any of those fields diverge while the
+  pool row is claim-owned, create/update the overlapping CR to match the pool
+  row.
+- **Overlap-only / stale overlap:** an overlapping row with no matching
+  claim-owned pool row, or whose claim is gone, is **deleted**. Do not keep
+  overlap state that would block a later allocation. Never remove or overwrite
+  an overlapping row whose IP is owned by a **different** live claim.
 
 A repair must never transfer an IP that another live claim already owns.
 
-**Claim identity on every reservation:** `IPAMClaimRef` (`<pod-namespace>/<claim-name>`).
-Assignment, deallocation, overlapping-range conflict checks, and GC compare this
-identity, not `PodRef` alone. Existing pod-only rows stay pod-scoped (empty
-claim fields).
+**Claim identity on every reservation:** `IPAMClaimRef`
+(`<pod-namespace>/<claim-name>`) **and** `IPAMClaimUID` (the claim object's
+UID). Assignment, deallocation, overlapping-range conflict checks, and GC
+compare both. A claim deleted and recreated with the same name is a different
+object and must not match a stale reservation.
+
+Existing **pod-only** rows (empty claim fields) stay pod-scoped.
+
+**Name-only claim rows** (upgrade from an earlier `IPAMClaimRef` without UID):
+on the first successful ADD or reconcile against a live claim of that
+namespace/name, stamp `IPAMClaimUID`. If no live claim exists, free the row.
+Do not treat a recreated same-name claim as the owner of a UID-stamped row
+for a previous UID. Operators should not delete/recreate claims during that
+one-time stamp.
 
 ### Changes in Modules
 
 1. `go.mod` — add `github.com/k8snetworkplumbingwg/ipamclaims` (API types + clientset).
 2. `pkg/types/types.go` — extend `IPAMConfig` / `Net` / `IPReservation`:
    ```go
-   IPAMClaimReference string // claim *name* only namespace is the pod namespace
+   IPAMClaimReference string // claim *name* only, namespace is the pod namespace
    IPAMClaimRef       string // on reservations: "namespace/name"
+   IPAMClaimUID       string // on reservations: claim object UID
    ```
    No `IPAMClaimNamespace` field on config.
-3. `pkg/ipamclaim/` — claim reference resolution (CNI args + pod NSE with
-   unambiguous matching), fail-closed validation of present-but-invalid
-   references, claim fetch in the pod namespace, `IPAMClaimSpec` network/interface
-   validation against the current attachment, and `status.ips` / `ownerPod`
-   persistence.
+3. `pkg/ipamclaim/` — claim reference resolution (precedence + conflict reject
+   across CNI fields and pod NSE, unambiguous NSE matching), fail-closed
+   validation of present-but-invalid references, claim fetch in the pod
+   namespace, `IPAMClaimSpec` network/interface validation against the current
+   attachment, and `status.ips` / `ownerPod` persistence.
 4. `pkg/config/config.go` (`LoadIPAMConfig`) — populate the claim **name** from CNI
-   stdin sources when present. Absent attribute: no behavior change. Present but
-   invalid: fail config load (do not ignore).
-5. `pkg/allocate/allocate.go` (`AssignIPForClaim`) — reuse by claim identity /
-   preferred IPs (idempotent take-over for stop/start and migration handoff) tag
-   new reservations with `IPAMClaimRef`.
-6. `pkg/api/...` + CRDs — `ipamclaimref` on `IPAllocation` and
+   stdin sources when present, applying the same precedence/conflict rules.
+   Absent attribute: no behavior change. Present but invalid: fail config load.
+5. `pkg/allocate/allocate.go` (`AssignIPForClaim`) — reuse by claim identity
+   (name + UID) / preferred IPs (idempotent take-over for stop/start and
+   migration handoff), tag new reservations with `IPAMClaimRef` + `IPAMClaimUID`.
+6. `pkg/api/...` + CRDs — `ipamclaimref` and `ipamclaimuid` on `IPAllocation` and
    `OverlappingRangeIPReservationSpec` (does **not** overload `PodRef`).
 7. `pkg/storage/kubernetes/ipam.go` — claim-aware Allocate / Deallocate:
    - Resolve claim in the pod namespace, validate `IPAMClaimSpec` against the
@@ -242,27 +275,35 @@ claim fields).
      pool/overlapping write.
    - Skip freeing claim-backed reservations on Deallocate.
    - Overlapping-range create treats AlreadyExists as claim take-over when the
-     existing row is owned by the same `IPAMClaimRef` (update `PodRef` / `IfName`).
-8. `pkg/controlloop` — **level-driven** claim reconcile: compare claim-tagged
-   pool and overlapping reservations to live `IPAMClaim` objects (add/update/delete
-   **and** periodic/resync). `garbageCollectPodIPs` skips any reservation with
-   non-empty `IPAMClaimRef` (release is claim-absence, not pod delete).
-9. `pkg/reconciler` — orphan GC uses the same live-claim check never frees on
-   lookup error.
-10. Install path — IPAMClaim CRD + RBAC for `ipamclaims` / `ipamclaims/status` in
-    daemonset, Helm chart, and kind e2e setup.
-11. **Tests / docs** — unit tests (config fail-closed parsing, unambiguous NSE
-    match, spec validation, allocate, complete overlapping-identity drift repair,
-    overlapping take-over). e2e covers allocate → retain across pod recreate →
-    release on claim delete. User docs (`doc/persistent-ips.md`) ship with the
-    implementation PR, not this design note. Live-migration e2e remains follow-up.
+     existing row is owned by the same `IPAMClaimRef` **and** UID (update
+     `PodRef` / `IfName`).
+8. `pkg/controlloop` — **level-driven** claim reconcile over the union of live
+   claims, pool rows, and overlapping rows (add/update/delete **and**
+   periodic/resync), including overlap-only cleanup. `garbageCollectPodIPs`
+   skips any reservation with non-empty `IPAMClaimRef` (release is
+   claim-absence, not pod delete).
+9. `pkg/reconciler` — orphan GC uses the same live-claim + UID check, never
+   frees on lookup error.
+10. Install path — IPAMClaim **CRD + RBAC** (`ipamclaims` / `ipamclaims/status`)
+    in daemonset, Helm chart, and kind e2e setup. This ships in the **same
+    rollout unit** as claim-aware allocate/deallocate/control-loop, not after
+    it. If the CRD or status permissions are missing, claim-aware paths must
+    not run (fail ADD / skip reconcile writes), do not allocate as if the
+    feature were enabled.
+11. **Tests / docs** — unit tests (source precedence and conflict combinations,
+    config fail-closed parsing, unambiguous NSE match, spec validation, UID
+    identity, name-only migration, bidirectional drift repair, overlap-only
+    removal, overlapping take-over). e2e covers allocate → retain across pod
+    recreate → release on claim delete. User docs (`doc/persistent-ips.md`)
+    ship with the implementation PR, not this design note. Live-migration e2e
+    remains follow-up.
 
 ### Lifecycle walk-through
 
 | Event                  | Actor                         | Result                                                                                                       |
 | ---------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | VM created             | ipam-extensions               | Creates `IPAMClaim` (empty `status.ips`), owned by the VM injects `ipam-claim-reference` on the launcher pod |
-| Pod ADD (first boot)   | Whereabouts                   | Resolve + validate claim/spec, `status.ips` empty → allocate, write `status.ips`, set `ownerPod`, tag `ipamclaimref` |
+| Pod ADD (first boot)   | Whereabouts                   | Resolve + validate claim/spec, allocate, tag `ipamclaimref` + UID, write `status.ips` / `ownerPod`           |
 | VM stop → pod DEL      | Whereabouts                   | Claim-backed → **keep** the IP control-loop / reconciler **skip** GC when `IPAMClaimRef` is set             |
 | VM start → new pod ADD | Whereabouts                   | Validate spec, `status.ips` populated → **reuse** the same IP (reservation handoff to new PodRef)            |
 | Live migration         | Whereabouts                   | Target pod ADD reuses the claim IP while source still holds it `ownerPod` hands off                         |
@@ -271,35 +312,48 @@ claim fields).
 ## Hard problems / remaining risks
 
 1. **Live migration overlap.** Source and target pods coexist and share the
-   claim's IP for a window. Take-over is allowed only for the same `IPAMClaimRef`.
-   Source DEL must not clear the target's reservation.
+   claim's IP for a window. Take-over is allowed only for the same `IPAMClaimRef`
+   **and** UID. Source DEL must not clear the target's reservation.
 2. **Overlapping-range reservations** — tagged with the same claim identity as
-   the pool row updated (not failed) on take-over included in drift reconcile.
+   the pool row, updated (not failed) on take-over, included in bidirectional
+   drift reconcile, overlap-only stale rows are removed.
 3. **Idempotency under churn** (old pod terminating while new pod starts) —
-   handled via `IPAMClaimRef` matching and preferred-IP take-over.
+   handled via `IPAMClaimRef` + UID matching and preferred-IP take-over.
 4. **Incomplete updates / drift** — pool-first writes plus level-driven
-   reconcile repair `status.ips` ↔ pool ↔ overlapping divergence without stealing
-   IPs owned by another live claim.
-5. **Controller downtime** — because cleanup is level-driven, a missed delete
+   reconcile over the union of claims, pool, and overlapping rows, repair
+   without stealing IPs owned by another live claim.
+5. **Claim recreate** — same name, new UID must not inherit a stale reservation.
+   Name-only rows are stamped once during upgrade.
+6. **Controller downtime** — because cleanup is level-driven, a missed delete
    event is healed on the next reconcile. Lookup errors never release.
 
 ## Delivery plan
 
-Originally planned as incremental PRs. **PR1–PR4 are one compatible rollout
-unit** and must not land independently: persisting `status.ips` without the DEL
-and GC protections would leave a claim holding an address after the pool record
-is freed, so another workload could acquire it. Implementation is tracked in
-[#742](https://github.com/k8snetworkplumbingwg/whereabouts/pull/742) (open not
+Originally planned as incremental PRs. **PR1–PR4 plus CRD/RBAC are one
+compatible rollout unit** and must not land independently: persisting
+`status.ips` without the DEL and GC protections would leave a claim holding an
+address after the pool record is freed, and enabling claim resolution/watches
+without the CRD and `ipamclaims`/`ipamclaims/status` RBAC would fail lookups or
+status updates while allocation code is on.
+
+**Upgrade order:** install CRD and RBAC first, then start claim-aware binaries.
+**Rollback order:** disable/roll back binaries first, then remove RBAC/CRD (or
+leave the CRD in place). If the CRD or status permissions are absent, gate the
+feature off (fail closed on claim-backed ADD, do not treat missing CRD as
+legacy allocation when a claim reference is present).
+
+Implementation is tracked in
+[#742](https://github.com/k8snetworkplumbingwg/whereabouts/pull/742) (open, not
 shipped). Live-migration e2e remains follow-up.
 
 | PR  | Scope                                                                         | Status                                      |
 | --- | ----------------------------------------------------------------------------- | ------------------------------------------- |
 | PR0 | This design note                                                              | this document                               |
-| PR1 | Vendor `ipamclaims` add `IPAMClaimReference` + config parsing                | in #742 (not merged)                        |
+| PR1 | Vendor `ipamclaims`, add `IPAMClaimReference` + config parsing, **CRD + RBAC** | in #742 (not merged)                        |
 | PR2 | Allocate path: reuse existing / persist new `status.ips`                      | in #742 (not merged)                        |
 | PR3 | Deallocate path: do not release claim-backed IPs on pod DEL                   | in #742 (not merged)                        |
-| PR4 | Control-loop: IPAMClaim-delete watcher + skip GC for claim-backed allocations | in #742 (not merged)                        |
-| PR5 | e2e (stop/start recreate) + docs + CRD/RBAC                                   | in #742 (not merged) migration e2e follow-up |
+| PR4 | Control-loop: IPAMClaim reconcile + skip GC for claim-backed allocations      | in #742 (not merged)                        |
+| PR5 | e2e (stop/start recreate) + user docs                                         | in #742 (not merged), migration e2e follow-up |
 
 ## Summary
 
@@ -315,11 +369,12 @@ backwards compatibility.
 ## Discussions and Decisions
 
 - **Reference transport** — Multus does not inject the NSE claim into delegate
-  IPAM stdin today. Whereabouts accepts CNI/`args.cni` when present and otherwise
-  resolves `ipam-claim-reference` (claim **name**) from the pod network-selection
-  annotation (same wiring as OVN-Kubernetes / ipam-extensions). NSE matching uses
-  both interface and network when both are set, a single-field match is valid
-  only when unique, ambiguity fails CNI ADD.
+  IPAM stdin today. Sources, highest precedence first: IPAM section, top-level
+  net field, `args.cni`, then the pod network-selection annotation. Present-but-
+  invalid values fail immediately. Distinct valid names from two sources are
+  rejected. NSE matching uses both interface and network when both are set, a
+  single-field match is valid only when unique, ambiguity fails CNI ADD. Tests
+  cover every source combination.
 - **Fail closed** — Only an **absent** `ipam-claim-reference` uses legacy
   pod-scoped allocation. A present-but-invalid or cross-namespace value is a
   validation error, not a silent fallback.
@@ -329,22 +384,26 @@ backwards compatibility.
 - **Claim namespace** — Pin to the workload (pod) namespace. Drop
   `IPAMClaimNamespace`, no cross-namespace claims.
 - **CR sync** — `IPPool.Spec.Allocations` is the authoritative lease,
-  `IPAMClaim.status.ips` is the persisted claim set. Reconcile must detect and
-  repair drift, including incomplete pool-vs-status updates, and must never steal
-  an IP another live claim owns.
-- **Overlapping CR** — Same `IPAMClaimRef` (`namespace/name`) and the same
+  `IPAMClaim.status.ips` is the persisted claim set. Reconcile walks the **union**
+  of live claims, pool rows, and overlapping rows so a claim with no pool row
+  is still repaired. Never steal an IP another live claim owns. Overlap-only
+  stale rows are deleted.
+- **Overlapping CR** — Same claim identity (`namespace/name` + UID) and the same
   sync/repair rules as the pool row, comparing the complete lease identity (IP,
-  `IPAMClaimRef`, `PodRef`, `IfName`, pool/network key). Take-over updates the
-  overlapping CR instead of treating the target pod as a conflict.
+  `IPAMClaimRef`, `IPAMClaimUID`, `PodRef`, `IfName`, pool/network key). Take-over
+  updates the overlapping CR instead of treating the target pod as a conflict.
 - **Live-migration handoff** — Target ADD reuses the claim IP, source DEL does
   not free it. `ownerPod` hands off, overlapping AlreadyExists is take-over for
-  the same `IPAMClaimRef`.
+  the same `IPAMClaimRef` + UID.
 - **Level-driven cleanup** — Do not rely only on IPAMClaim delete events.
-  Reconcile claim-tagged reservations against live claims on resync/periodic
-  sync. API/informer errors are retryable and must not release.
-- **Reservation tagging** — Dedicated `IPAMClaimRef` on IPPool allocations and
-  overlapping reservations (does not overload `PodRef`).
+  Reconcile the union of live claims and both reservation stores on
+  resync/periodic sync. API/informer errors are retryable and must not release.
+- **Reservation tagging** — Dedicated `IPAMClaimRef` + `IPAMClaimUID` on IPPool
+  allocations and overlapping reservations (does not overload `PodRef`). Name-only
+  rows are a one-time upgrade stamp against the live claim of that name.
 - **Rollout** — Allocate-path persist (`status.ips`) must not ship without DEL
-  and GC protections. PR1–PR4 are one rollout unit in
+  and GC protections, and claim-aware code must not ship without the IPAMClaim
+  CRD and RBAC. Upgrade: CRD/RBAC first, then binaries. Rollback: binaries
+  first. PR1–PR4 (including install path) are one rollout unit in
   [whereabouts#742](https://github.com/k8snetworkplumbingwg/whereabouts/pull/742)
   (open). Live-migration e2e is follow-up.

--- a/doc/proposals/persistent-ips-ipamclaims.md
+++ b/doc/proposals/persistent-ips-ipamclaims.md
@@ -1,11 +1,10 @@
 # Persistent IPs for KubeVirt VMs via the IPAMClaim standard
 
-Status: **Implemented** (whereabouts#742 targets whereabouts#557, whereabouts#500)
+Status: **Proposed** (implementation in
+[whereabouts#742](https://github.com/k8snetworkplumbingwg/whereabouts/pull/742),
+user-facing docs `doc/persistent-ips.md` land with that PR, not this design note).
 
-User-facing docs: `doc/persistent-ips.md` (ships with
-[whereabouts#742](https://github.com/k8snetworkplumbingwg/whereabouts/pull/742)).
-
-This proposal describes how Whereabouts implements the multi-network de-facto
+This proposal describes how Whereabouts will implement the multi-network de-facto
 standard `IPAMClaim` contract so that KubeVirt VirtualMachines keep a stable IP
 across stop/start and live migration — the same capability OVN-Kubernetes already
 provides through [kubevirt/ipam-extensions](https://github.com/kubevirt/ipam-extensions)
@@ -101,9 +100,16 @@ type IPAMClaimStatus struct {
 
 Expected plugin behavior:
 
-- **CNI ADD**: if the referenced claim's `status.ips` is non-empty, **reuse** those
-addresses (atomically reserve them in the pool / overlapping CR). Otherwise allocate
-normally and **write** `status.ips` (and set `status.ownerPod`).
+- **CNI ADD**:
+  1. Resolve the claim reference (see [How the claim reference reaches Whereabouts](#how-the-claim-reference-reaches-whereabouts)).
+  2. **Validate `IPAMClaimSpec` before any pool or status write.** `spec.network`
+     and `spec.interface` must match the current CNI attachment (network name and
+     interface). A mismatch **fails the ADD** and must not allocate, take over, or
+     update `status.ips` / `ownerPod`. The same check applies to both first
+     allocation (empty `status.ips`) and reuse (populated `status.ips`).
+  3. If `status.ips` is non-empty, **reuse** those addresses (atomically reserve
+     them in the pool / overlapping CR). Otherwise allocate normally and **write**
+     `status.ips` (and set `status.ownerPod`).
 - **CNI DEL**: if the allocation is claim-backed, **do not release** the IP.
 - **Release** happens when the `IPAMClaim` itself is gone — observed by a
 **level-driven** reconcile against live claims, not only by a delete event
@@ -128,14 +134,25 @@ wiring keeps the claim on the pod annotation. Whereabouts therefore:
 
 1. Accepts `ipam-claim-reference` from CNI config when present (IPAM section,
    top-level net field, or `args.cni`) — useful for tests and future Multus
-   injection.
-2. If still empty, **resolves the claim from the pod's network-selection
-   annotation** via the Kubernetes API, matching on interface name and/or network
-   name.
+   injection. A present-but-invalid value here **fails immediately**, it does
+   not fall through to the annotation.
+2. If the attribute is still **absent**, **resolves the claim from the pod's
+   network-selection annotation** via the Kubernetes API:
+   - When both interface name and network name are available, match **both**.
+   - A single-field match (interface **or** network) is allowed only when it
+     yields **exactly one** candidate.
+   - Ambiguous matches (the same network attached more than once, or multiple
+     NSEs that satisfy a single-field filter) **fail CNI ADD**. Do not pick an
+     arbitrary NSE.
 
-`ipam-claim-reference` is a **claim name only**. Empty or malformed values are
-ignored (legacy pod-scoped allocation). Cross-namespace names (`ns/name`) are
-rejected.
+`ipam-claim-reference` is a **claim name only**. Fail closed:
+
+- **Absent** (the attribute is not set on any resolved source): legacy
+  pod-scoped allocation.
+- **Present but invalid** (empty string, whitespace-only, non-string, `ns/name`,
+  or any other malformed value): **return a validation error**. Do **not** fall
+  back to pod-scoped allocation. A typo must not silently lose persistence on
+  pod DEL.
 
 ### Claim namespace
 
@@ -165,11 +182,11 @@ those steps leaves a claim-tagged reservation with empty `status.ips`, which
 reconcile heals by completing the status write — never by freeing the IP while
 the claim still exists.
 
-**Reuse (CNI ADD with populated `status.ips`):** validate network, interface,
-address family, and pool membership. Atomically take over each address only if it
-is free or already owned by **this** claim (match on `IPAMClaimRef`,
-`namespace/name`). Resource-version conflicts retry. Never steal an IP owned by
-a different live claim.
+**Reuse (CNI ADD with populated `status.ips`):** after the `IPAMClaimSpec`
+network/interface check above, also validate address family and pool membership.
+Atomically take over each address only if it is free or already owned by **this**
+claim (match on `IPAMClaimRef`, `namespace/name`). Resource-version conflicts
+retry. Never steal an IP owned by a different live claim.
 
 **Reconcile (level-driven, not only delete events):** periodically, and on
 informer resync / claim add-update-delete, walk claim-tagged pool and overlapping
@@ -183,9 +200,12 @@ rows and compare them to live `IPAMClaim` objects:
   not steal.
 - Claim exists, pool row tagged for this claim, IP **not** in `status.ips` →
   treat as incomplete persist write the IP into `status.ips` rather than free.
-- Overlapping CR missing or pointing at the wrong `PodRef` while the pool row is
-  claim-owned → create/update the overlapping CR to match. Never leave overlapping
-  state that would reject a later take-over.
+- Overlapping CR vs pool row: compare the **complete lease identity** — IP,
+  `IPAMClaimRef`, `PodRef`, `IfName`, and the pool/network key. If the overlapping
+  row is missing **or** any of those fields diverge while the pool row is
+  claim-owned, create/update the overlapping CR to match the pool row. A matching
+  `PodRef` with a wrong IP, `IPAMClaimRef`, or `IfName` is still drift and must
+  be repaired. Never leave overlapping state that would reject a later take-over.
 
 A repair must never transfer an IP that another live claim already owns.
 
@@ -203,18 +223,23 @@ claim fields).
    IPAMClaimRef       string // on reservations: "namespace/name"
    ```
    No `IPAMClaimNamespace` field on config.
-3. `pkg/ipamclaim/` — claim reference resolution (CNI args + pod NSE), claim fetch
-   in the pod namespace, and `status.ips` / `ownerPod` persistence.
+3. `pkg/ipamclaim/` — claim reference resolution (CNI args + pod NSE with
+   unambiguous matching), fail-closed validation of present-but-invalid
+   references, claim fetch in the pod namespace, `IPAMClaimSpec` network/interface
+   validation against the current attachment, and `status.ips` / `ownerPod`
+   persistence.
 4. `pkg/config/config.go` (`LoadIPAMConfig`) — populate the claim **name** from CNI
-   stdin sources when present. No behavior change when empty.
+   stdin sources when present. Absent attribute: no behavior change. Present but
+   invalid: fail config load (do not ignore).
 5. `pkg/allocate/allocate.go` (`AssignIPForClaim`) — reuse by claim identity /
    preferred IPs (idempotent take-over for stop/start and migration handoff) tag
    new reservations with `IPAMClaimRef`.
 6. `pkg/api/...` + CRDs — `ipamclaimref` on `IPAllocation` and
    `OverlappingRangeIPReservationSpec` (does **not** overload `PodRef`).
 7. `pkg/storage/kubernetes/ipam.go` — claim-aware Allocate / Deallocate:
-   - Resolve claim in the pod namespace, reuse or allocate, persist status after
-     the pool/overlapping write.
+   - Resolve claim in the pod namespace, validate `IPAMClaimSpec` against the
+     current attachment, then reuse or allocate, persist status after the
+     pool/overlapping write.
    - Skip freeing claim-backed reservations on Deallocate.
    - Overlapping-range create treats AlreadyExists as claim take-over when the
      existing row is owned by the same `IPAMClaimRef` (update `PodRef` / `IfName`).
@@ -226,18 +251,20 @@ claim fields).
    lookup error.
 10. Install path — IPAMClaim CRD + RBAC for `ipamclaims` / `ipamclaims/status` in
     daemonset, Helm chart, and kind e2e setup.
-11. **Tests / docs** — unit tests (config, allocate, drift repair, overlapping
-    take-over) e2e covers allocate → retain across pod recreate → release on
-    claim delete user docs (`doc/persistent-ips.md`).
+11. **Tests / docs** — unit tests (config fail-closed parsing, unambiguous NSE
+    match, spec validation, allocate, complete overlapping-identity drift repair,
+    overlapping take-over). e2e covers allocate → retain across pod recreate →
+    release on claim delete. User docs (`doc/persistent-ips.md`) ship with the
+    implementation PR, not this design note. Live-migration e2e remains follow-up.
 
 ### Lifecycle walk-through
 
 | Event                  | Actor                         | Result                                                                                                       |
 | ---------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | VM created             | ipam-extensions               | Creates `IPAMClaim` (empty `status.ips`), owned by the VM injects `ipam-claim-reference` on the launcher pod |
-| Pod ADD (first boot)   | Whereabouts                   | Resolve claim from NSE/config `status.ips` empty → allocate, write `status.ips`, set `ownerPod`, tag `ipamclaimref` |
+| Pod ADD (first boot)   | Whereabouts                   | Resolve + validate claim/spec, `status.ips` empty → allocate, write `status.ips`, set `ownerPod`, tag `ipamclaimref` |
 | VM stop → pod DEL      | Whereabouts                   | Claim-backed → **keep** the IP control-loop / reconciler **skip** GC when `IPAMClaimRef` is set             |
-| VM start → new pod ADD | Whereabouts                   | `status.ips` populated → **reuse** the same IP (reservation handoff to new PodRef)                           |
+| VM start → new pod ADD | Whereabouts                   | Validate spec, `status.ips` populated → **reuse** the same IP (reservation handoff to new PodRef)            |
 | Live migration         | Whereabouts                   | Target pod ADD reuses the claim IP while source still holds it `ownerPod` hands off                         |
 | VM deleted             | ipam-extensions → Whereabouts | `IPAMClaim` deleted → claim controller **frees** pool / overlapping reservations                             |
 
@@ -258,49 +285,66 @@ claim fields).
 
 ## Delivery plan
 
-Originally planned as incremental PRs shipped together in
-[#742](https://github.com/k8snetworkplumbingwg/whereabouts/pull/742):
+Originally planned as incremental PRs. **PR1–PR4 are one compatible rollout
+unit** and must not land independently: persisting `status.ips` without the DEL
+and GC protections would leave a claim holding an address after the pool record
+is freed, so another workload could acquire it. Implementation is tracked in
+[#742](https://github.com/k8snetworkplumbingwg/whereabouts/pull/742) (open not
+shipped). Live-migration e2e remains follow-up.
 
 | PR  | Scope                                                                         | Status                                      |
 | --- | ----------------------------------------------------------------------------- | ------------------------------------------- |
 | PR0 | This design note                                                              | this document                               |
-| PR1 | Vendor `ipamclaims` add `IPAMClaimReference` + config parsing                | done in #742                                |
-| PR2 | Allocate path: reuse existing / persist new `status.ips`                      | done in #742                                |
-| PR3 | Deallocate path: do not release claim-backed IPs on pod DEL                   | done in #742                                |
-| PR4 | Control-loop: IPAMClaim-delete watcher + skip GC for claim-backed allocations | done in #742                                |
-| PR5 | e2e (stop/start recreate) + docs + CRD/RBAC                                   | done in #742 migration e2e still follow-up |
+| PR1 | Vendor `ipamclaims` add `IPAMClaimReference` + config parsing                | in #742 (not merged)                        |
+| PR2 | Allocate path: reuse existing / persist new `status.ips`                      | in #742 (not merged)                        |
+| PR3 | Deallocate path: do not release claim-backed IPs on pod DEL                   | in #742 (not merged)                        |
+| PR4 | Control-loop: IPAMClaim-delete watcher + skip GC for claim-backed allocations | in #742 (not merged)                        |
+| PR5 | e2e (stop/start recreate) + docs + CRD/RBAC                                   | in #742 (not merged) migration e2e follow-up |
 
 ## Summary
 
-Anchor persistent allocations to the `IPAMClaim` (pod-independent, VM-owned) instead
-of the pod. On ADD, resolve the claim (primarily from the pod NSE), reuse
-`status.ips` when present else allocate and persist them on pod DEL, keep
-claim-backed IPs release only when the claim is deleted. This makes Whereabouts
-interoperable with the existing `ipam-extensions`/`IPAMClaim` machinery,
-delivering persistent VM IPs on non-OVN-Kubernetes clusters with no KubeVirt API
-change and full backwards compatibility.
+Anchor persistent allocations to the `IPAMClaim` (pod-independent, VM-owned)
+instead of the pod. On ADD, resolve the claim (primarily from the pod NSE),
+validate `spec.network` / `spec.interface`, and reuse `status.ips` when present.
+Otherwise, allocate and persist the IPs. On pod DEL, keep claim-backed IPs.
+Release them only when the claim is deleted. This makes Whereabouts interoperable
+with the existing `ipam-extensions`/`IPAMClaim` machinery, delivering persistent
+VM IPs on non-OVN-Kubernetes clusters with no KubeVirt API change and full
+backwards compatibility.
 
 ## Discussions and Decisions
 
 - **Reference transport** — Multus does not inject the NSE claim into delegate
   IPAM stdin today. Whereabouts accepts CNI/`args.cni` when present and otherwise
   resolves `ipam-claim-reference` (claim **name**) from the pod network-selection
-  annotation (same wiring as OVN-Kubernetes / ipam-extensions).
+  annotation (same wiring as OVN-Kubernetes / ipam-extensions). NSE matching uses
+  both interface and network when both are set, a single-field match is valid
+  only when unique, ambiguity fails CNI ADD.
+- **Fail closed** — Only an **absent** `ipam-claim-reference` uses legacy
+  pod-scoped allocation. A present-but-invalid or cross-namespace value is a
+  validation error, not a silent fallback.
+- **Claim spec validation** — Before first allocation and before reuse, require
+  `IPAMClaimSpec.Network` and `Interface` to match the current CNI attachment.
+  Mismatch fails ADD with no pool or claim-status change.
 - **Claim namespace** — Pin to the workload (pod) namespace. Drop
-  `IPAMClaimNamespace` no cross-namespace claims.
-- **CR sync** — `IPPool.Spec.Allocations` is the authoritative lease
+  `IPAMClaimNamespace`, no cross-namespace claims.
+- **CR sync** — `IPPool.Spec.Allocations` is the authoritative lease,
   `IPAMClaim.status.ips` is the persisted claim set. Reconcile must detect and
   repair drift, including incomplete pool-vs-status updates, and must never steal
   an IP another live claim owns.
 - **Overlapping CR** — Same `IPAMClaimRef` (`namespace/name`) and the same
-  sync/repair rules as the pool row. Take-over updates the overlapping CR instead
-  of treating the target pod as a conflict.
-- **Live-migration handoff** — Target ADD reuses the claim IP source DEL does
-  not free it. `ownerPod` hands off overlapping AlreadyExists is take-over for
+  sync/repair rules as the pool row, comparing the complete lease identity (IP,
+  `IPAMClaimRef`, `PodRef`, `IfName`, pool/network key). Take-over updates the
+  overlapping CR instead of treating the target pod as a conflict.
+- **Live-migration handoff** — Target ADD reuses the claim IP, source DEL does
+  not free it. `ownerPod` hands off, overlapping AlreadyExists is take-over for
   the same `IPAMClaimRef`.
 - **Level-driven cleanup** — Do not rely only on IPAMClaim delete events.
   Reconcile claim-tagged reservations against live claims on resync/periodic
   sync. API/informer errors are retryable and must not release.
 - **Reservation tagging** — Dedicated `IPAMClaimRef` on IPPool allocations and
   overlapping reservations (does not overload `PodRef`).
-- **Implementation** — [whereabouts#742](https://github.com/k8snetworkplumbingwg/whereabouts/pull/742).
+- **Rollout** — Allocate-path persist (`status.ips`) must not ship without DEL
+  and GC protections. PR1–PR4 are one rollout unit in
+  [whereabouts#742](https://github.com/k8snetworkplumbingwg/whereabouts/pull/742)
+  (open). Live-migration e2e is follow-up.

--- a/doc/proposals/persistent-ips-ipamclaims.md
+++ b/doc/proposals/persistent-ips-ipamclaims.md
@@ -1,12 +1,15 @@
 # Persistent IPs for KubeVirt VMs via the IPAMClaim standard
 
-Status: **Draft / for discussion** (targets whereabouts#557, whereabouts#500)
+Status: **Implemented** (whereabouts#742 targets whereabouts#557, whereabouts#500)
 
-This proposal describes how Whereabouts can implement the multi-network de-facto
+User-facing docs: `doc/persistent-ips.md` (ships with
+[whereabouts#742](https://github.com/k8snetworkplumbingwg/whereabouts/pull/742)).
+
+This proposal describes how Whereabouts implements the multi-network de-facto
 standard `IPAMClaim` contract so that KubeVirt VirtualMachines keep a stable IP
 across stop/start and live migration — the same capability OVN-Kubernetes already
-provides through `[kubevirt/ipam-extensions](https://github.com/kubevirt/ipam-extensions)`
-and the `[ipamclaims](https://github.com/k8snetworkplumbingwg/ipamclaims)` CRD — **without**
+provides through [kubevirt/ipam-extensions](https://github.com/kubevirt/ipam-extensions)
+and the [ipamclaims](https://github.com/k8snetworkplumbingwg/ipamclaims) CRD — **without**
 requiring OVN-Kubernetes and **without** any KubeVirt core API change.
 
 # Table of contents
@@ -20,12 +23,10 @@ requiring OVN-Kubernetes and **without** any KubeVirt core API change.
   - [How the claim reference reaches Whereabouts](#how-the-claim-reference-reaches-whereabouts)
   - [Changes in Modules](#changes-in-modules)
   - [Lifecycle walk-through](#lifecycle-walk-through)
-- [Hard problems / open questions](#hard-problems--open-questions)
+- [Hard problems / remaining risks](#hard-problems--remaining-risks)
 - [Delivery plan](#delivery-plan)
 - [Summary](#summary)
 - [Discussions and Decisions](#discussions-and-decisions)
-
-
 
 ## Introduction
 
@@ -40,7 +41,8 @@ Upstream KubeVirt has intentionally chosen **not** to solve this in KubeVirt cor
 Instead, persistent VM IPs are handled at the IPAM layer through the `IPAMClaim`
 CRD: a controller (`ipam-extensions`) creates an `IPAMClaim` owned by the VM, and
 the IPAM plugin persists the allocation against that claim rather than against the
-pod. OVN-Kubernetes already honors these claims Whereabouts does not yet.
+pod. OVN-Kubernetes already honors these claims Whereabouts now does as well
+([#742](https://github.com/k8snetworkplumbingwg/whereabouts/pull/742)).
 
 ### Goal of this proposal
 
@@ -52,18 +54,15 @@ API and no changes to KubeVirt.
 - Remain fully backwards compatible: pods without a claim reference behave exactly
 as today.
 
-
-
 ### Non-goals
 
 - Creating or deleting `IPAMClaim` resources. That is `ipam-extensions`' job the
 claim is owned by the VM and its lifecycle is managed by the controller.
-- Persistent IPs for arbitrary (non-KubeVirt) pods, though the mechanism is generic.
+- Persistent IPs for arbitrary (non-KubeVirt) pods, though the mechanism is generic
+(manual claims work; see `doc/persistent-ips.md` in #742).
 - Any change to KubeVirt core (a bespoke `persistIP` field was proposed in
 kubevirt/kubevirt#18636 and declined as out of scope for core — this proposal is
 the maintainer-recommended alternative).
-
-
 
 ## Background: how allocation works today
 
@@ -108,116 +107,123 @@ addresses. Otherwise allocate normally and **write** `status.ips` (and set
 - **Release** happens only when the `IPAMClaim` itself is deleted (which
 `ipam-extensions` triggers when the VM is deleted).
 
-
-
 ## Design
-
-
 
 ### How the claim reference reaches Whereabouts
 
 `ipam-extensions` adds an `ipam-claim-reference` attribute to the VM pod's
-`k8s.v1.cni.cncf.io/networks` network-selection element for the eligible interface,
-and Multus forwards network-selection-element attributes to the delegate plugin.
+`k8s.v1.cni.cncf.io/networks` network-selection element (NSE) for the eligible
+interface.
 
-> **Open item to confirm before PR1:** the exact transport by which the reference
-> reaches the delegate IPAM plugin — a top-level field injected into the delegate
-> CNI config, `RuntimeConfig`, or `CNI_ARGS`. We will mirror whatever OVN-Kubernetes
-> reads (it is the reference implementation) so Whereabouts is drop-in compatible
-> with the same `ipam-extensions`/Multus wiring.
+**Resolved (mirrors OVN-Kubernetes / ipam-extensions):** Multus does **not**
+currently inject `NSE.IPAMClaimReference` into delegate IPAM CNI stdin. Production
+wiring keeps the claim on the pod annotation. Whereabouts therefore:
 
+1. Accepts `ipam-claim-reference` from CNI config when present (IPAM section,
+   top-level net field, or `args.cni`) — useful for tests and future Multus
+   injection.
+2. If still empty, **resolves the claim from the pod's network-selection
+   annotation** via the Kubernetes API (`pkg/ipamclaim.ResolveFromPodAnnotation`),
+   matching on interface name and/or network name.
 
+Claim namespace defaults to the pod namespace.
 
 ### Changes in Modules
 
-1. `go.mod` **/ vendor** — add `github.com/k8snetworkplumbingwg/ipamclaims`
-  (API types + generated clientset).
-2. `pkg/types/types.go` — extend `IPAMConfig`:
-  ```go
+As implemented in [#742](https://github.com/k8snetworkplumbingwg/whereabouts/pull/742):
+
+1. `go.mod` — add `github.com/k8snetworkplumbingwg/ipamclaims` (API types + clientset).
+2. `pkg/types/types.go` — extend `IPAMConfig` / `Net` / `IPReservation`:
+   ```go
    IPAMClaimReference string // name of the IPAMClaim, empty => legacy behavior
    IPAMClaimNamespace string // usually the pod namespace
-  ```
-3. `pkg/config/config.go` **(**`LoadIPAMConfig`**)** — populate the fields above from
-  the transport confirmed in the open item. No behavior change when empty.
-4. `pkg/storage/kubernetes/ipam.go` **(**`IPManagement`**,** `Allocate` **branch)** —
-  claim-aware allocation:
-  - Fetch the `IPAMClaim`.
-  - `len(status.ips) > 0` → reuse those IPs reserve them **idempotently** (a repeat
-  reservation for the same claim is a success, not a conflict).
-  - else → allocate as today, then patch `status.ips` + `status.ownerPod`.
-  - Tag the pool/overlapping reservation so it is recognizable as claim-backed
-  (e.g. store the claim ref alongside `PodRef`).
-5. `pkg/storage/kubernetes/ipam.go` **(**`Deallocate` **branch)** — if the reservation
-  is claim-backed, skip freeing the address (optionally clear `ownerPod`) keep the
-   reservation intact so the next pod re-acquires the same IP.
-6. `pkg/controlloop` — release on claim deletion, not pod deletion:
-  - Add an `IPAMClaim` informer on **delete**, free the claim's reserved IPs via
-   the existing `Deallocate` cleanup path.
-  - In `garbageCollectPodIPs`, skip GC for a claim-backed allocation whose claim
-  still exists (a generalization of the current StatefulSet guard).
-7. **Tests** — unit tests for config parsing, reuse-vs-allocate, and DEL-no-release
-  an `e2e/` scenario exercising VM stop/start and (ideally) migration.
-
-
+   IPAMClaimRef       string // on reservations: "namespace/name"
+   ```
+3. `pkg/ipamclaim/` — claim reference resolution (CNI args + pod NSE), claim fetch,
+   and `status.ips` / `ownerPod` persistence.
+4. `pkg/config/config.go` (`LoadIPAMConfig`) — populate claim fields from CNI stdin
+   sources when present. No behavior change when empty.
+5. `pkg/allocate/allocate.go` (`AssignIPForClaim`) — reuse by claim ref / preferred
+   IPs (idempotent take-over for stop/start and migration handoff) tag new
+   reservations with `IPAMClaimRef`.
+6. `pkg/api/...` + CRDs — dedicated `ipamclaimref` on `IPAllocation` and
+   `OverlappingRangeIPReservationSpec` (does **not** overload `PodRef`).
+7. `pkg/storage/kubernetes/ipam.go` — claim-aware Allocate / Deallocate:
+   - Resolve claim, fetch `IPAMClaim`, reuse or allocate, persist status.
+   - Skip freeing claim-backed reservations on Deallocate.
+   - Overlapping-range create treats AlreadyExists as claim take-over (update
+     PodRef / IfName / IPAMClaimRef).
+8. `pkg/controlloop` — `ClaimController` watches IPAMClaim **delete** and frees
+   matching pool / overlapping reservations. `garbageCollectPodIPs` skips any
+   reservation with non-empty `IPAMClaimRef` (release is claim-delete only).
+9. `pkg/reconciler` — orphan GC also skips claim-backed reservations.
+10. Install path — IPAMClaim CRD + RBAC for `ipamclaims` / `ipamclaims/status` in
+    daemonset, Helm chart, and kind e2e setup.
+11. **Tests / docs** — unit tests (config, allocate, reference) e2e covers
+    allocate → retain across pod recreate → release on claim delete; user docs
+    (`doc/persistent-ips.md`) ship in #742. Live-migration e2e is not yet covered.
 
 ### Lifecycle walk-through
-
 
 | Event                  | Actor                         | Result                                                                                                       |
 | ---------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | VM created             | ipam-extensions               | Creates `IPAMClaim` (empty `status.ips`), owned by the VM injects `ipam-claim-reference` on the launcher pod |
-| Pod ADD (first boot)   | Whereabouts                   | `status.ips` empty → allocate, write `status.ips`, set `ownerPod`                                            |
-| VM stop → pod DEL      | Whereabouts                   | Claim-backed → **keep** the IP control-loop **skips** GC because the claim still exists                      |
-| VM start → new pod ADD | Whereabouts                   | `status.ips` populated → **reuse** the same IP                                                               |
-| Live migration         | Whereabouts                   | Target pod ADD reuses the claim IP while source still holds it `ownerPod` hands off                          |
-| VM deleted             | ipam-extensions → Whereabouts | `IPAMClaim` deleted → control-loop **frees** the IP                                                          |
+| Pod ADD (first boot)   | Whereabouts                   | Resolve claim from NSE/config `status.ips` empty → allocate, write `status.ips`, set `ownerPod`, tag `ipamclaimref` |
+| VM stop → pod DEL      | Whereabouts                   | Claim-backed → **keep** the IP control-loop / reconciler **skip** GC when `IPAMClaimRef` is set             |
+| VM start → new pod ADD | Whereabouts                   | `status.ips` populated → **reuse** the same IP (reservation handoff to new PodRef)                           |
+| Live migration         | Whereabouts                   | Target pod ADD reuses the claim IP while source still holds it `ownerPod` hands off                         |
+| VM deleted             | ipam-extensions → Whereabouts | `IPAMClaim` deleted → claim controller **frees** pool / overlapping reservations                             |
 
-
-
-
-## Hard problems / open questions
+## Hard problems / remaining risks
 
 1. **Live migration overlap.** Source and target `virt-launcher` pods coexist and
-  share the claim's IP for a window. The target must be allowed to reuse the IP
-   while the source reservation still exists `status.ownerPod` mediates the handoff.
-   This is the primary concurrency risk and needs explicit review.
-2. **Overlapping-range reservations** are pod-keyed today re-acquiring the same IP
-  for a new pod must not be treated as a duplicate/conflict.
-3. **Idempotency under churn** (old pod terminating while new pod starts).
-4. **Stale reconciliation** — if the control-loop was down when a claim was deleted,
-  the informer resync must free orphaned reservations.
-5. **Reference transport** — the one item to confirm against OVN-Kubernetes/Multus
-  (see above) before locking the config parsing.
-
-
+  share the claim's IP for a window. Implementation allows take-over of an
+  existing claim-backed reservation and preferred IPs from `status.ips`, and
+  updates overlapping reservations on AlreadyExists. Concurrent ADD under heavy
+  churn remains the main risk area e2e covers stop/start recreate, not full
+  KubeVirt migration yet.
+2. **Overlapping-range reservations** — addressed by tagging with `IPAMClaimRef`
+  and updating (not failing) when the same IP is re-acquired for a new pod.
+3. **Idempotency under churn** (old pod terminating while new pod starts) —
+  handled via claim-ref matching and preferred-IP take-over in `AssignIPForClaim`.
+4. **Stale reconciliation** — pod/reconciler GC never frees claim-backed rows
+  only the IPAMClaim-delete controller does. If that controller was down across
+  a claim delete, a restart + delete-event (or operator re-delete) is needed to
+  free orphans broader resync cleanup is a follow-up if needed.
 
 ## Delivery plan
 
+Originally planned as incremental PRs shipped together in
+[#742](https://github.com/k8snetworkplumbingwg/whereabouts/pull/742):
 
-| PR  | Scope                                                                         | Risk   |
-| --- | ----------------------------------------------------------------------------- | ------ |
-| PR0 | This design note align at a community meeting                                 | none   |
-| PR1 | Vendor `ipamclaims` add `IPAMClaimReference` + config parsing (inert)         | low    |
-| PR2 | Allocate path: reuse existing / persist new `status.ips`                      | medium |
-| PR3 | Deallocate path: do not release claim-backed IPs on pod DEL                   | medium |
-| PR4 | Control-loop: IPAMClaim-delete watcher + skip GC for claim-backed allocations | medium |
-| PR5 | e2e (stop/start + migration) and docs                                         | low    |
-
-
-
+| PR  | Scope                                                                         | Status                                      |
+| --- | ----------------------------------------------------------------------------- | ------------------------------------------- |
+| PR0 | This design note                                                              | this document                               |
+| PR1 | Vendor `ipamclaims` add `IPAMClaimReference` + config parsing                | done in #742                                |
+| PR2 | Allocate path: reuse existing / persist new `status.ips`                      | done in #742                                |
+| PR3 | Deallocate path: do not release claim-backed IPs on pod DEL                   | done in #742                                |
+| PR4 | Control-loop: IPAMClaim-delete watcher + skip GC for claim-backed allocations | done in #742                                |
+| PR5 | e2e (stop/start recreate) + docs + CRD/RBAC                                   | done in #742 migration e2e still follow-up |
 
 ## Summary
 
 Anchor persistent allocations to the `IPAMClaim` (pod-independent, VM-owned) instead
-of the pod. On ADD, reuse `status.ips` when present else allocate and persist them
-on pod DEL, keep claim-backed IPs release only when the claim is deleted. This makes
-Whereabouts interoperable with the existing `ipam-extensions`/`IPAMClaim` machinery,
+of the pod. On ADD, resolve the claim (primarily from the pod NSE), reuse
+`status.ips` when present else allocate and persist them on pod DEL, keep
+claim-backed IPs release only when the claim is deleted. This makes Whereabouts
+interoperable with the existing `ipam-extensions`/`IPAMClaim` machinery,
 delivering persistent VM IPs on non-OVN-Kubernetes clusters with no KubeVirt API
 change and full backwards compatibility.
 
 ## Discussions and Decisions
 
-- *TBD* — reference-transport mechanism confirmed against OVN-Kubernetes.
-- *TBD* — live-migration handoff semantics (`ownerPod`) agreed with maintainers.
-- *TBD* — whether reservation records gain a dedicated claim field or overload `PodRef`.
-
+- **Reference transport** — Multus does not inject the NSE claim into delegate
+  IPAM stdin today. Whereabouts accepts CNI/`args.cni` when present and otherwise
+  resolves `ipam-claim-reference` from the pod network-selection annotation
+  (same wiring as OVN-Kubernetes / ipam-extensions).
+- **Live-migration handoff** — reuse claim-backed pool reservations and
+  `status.ips` preferred addresses update `status.ownerPod` on ADD overlapping
+  AlreadyExists is treated as take-over. Full migration e2e remains a follow-up.
+- **Reservation tagging** — dedicated `IPAMClaimRef` / `ipamclaimref` field on
+  IPPool allocations and overlapping reservations (does not overload `PodRef`).
+- **Implementation** — [whereabouts#742](https://github.com/k8snetworkplumbingwg/whereabouts/pull/742).

--- a/doc/proposals/persistent-ips-ipamclaims.md
+++ b/doc/proposals/persistent-ips-ipamclaims.md
@@ -21,6 +21,8 @@ requiring OVN-Kubernetes and **without** any KubeVirt core API change.
 - [The IPAMClaim contract](#the-ipamclaim-contract)
 - [Design](#design)
   - [How the claim reference reaches Whereabouts](#how-the-claim-reference-reaches-whereabouts)
+  - [Claim namespace](#claim-namespace)
+  - [Keeping the CRs in sync](#keeping-the-crs-in-sync)
   - [Changes in Modules](#changes-in-modules)
   - [Lifecycle walk-through](#lifecycle-walk-through)
 - [Hard problems / remaining risks](#hard-problems--remaining-risks)
@@ -41,8 +43,7 @@ Upstream KubeVirt has intentionally chosen **not** to solve this in KubeVirt cor
 Instead, persistent VM IPs are handled at the IPAM layer through the `IPAMClaim`
 CRD: a controller (`ipam-extensions`) creates an `IPAMClaim` owned by the VM, and
 the IPAM plugin persists the allocation against that claim rather than against the
-pod. OVN-Kubernetes already honors these claims Whereabouts now does as well
-([#742](https://github.com/k8snetworkplumbingwg/whereabouts/pull/742)).
+pod. OVN-Kubernetes already honors these claims Whereabouts should as well.
 
 ### Goal of this proposal
 
@@ -59,7 +60,7 @@ as today.
 - Creating or deleting `IPAMClaim` resources. That is `ipam-extensions`' job the
 claim is owned by the VM and its lifecycle is managed by the controller.
 - Persistent IPs for arbitrary (non-KubeVirt) pods, though the mechanism is generic
-(manual claims work; see `doc/persistent-ips.md` in #742).
+(manual claims in the workload namespace work).
 - Any change to KubeVirt core (a bespoke `persistIP` field was proposed in
 kubevirt/kubevirt#18636 and declined as out of scope for core — this proposal is
 the maintainer-recommended alternative).
@@ -101,11 +102,17 @@ type IPAMClaimStatus struct {
 Expected plugin behavior:
 
 - **CNI ADD**: if the referenced claim's `status.ips` is non-empty, **reuse** those
-addresses. Otherwise allocate normally and **write** `status.ips` (and set
-`status.ownerPod`).
+addresses (atomically reserve them in the pool / overlapping CR). Otherwise allocate
+normally and **write** `status.ips` (and set `status.ownerPod`).
 - **CNI DEL**: if the allocation is claim-backed, **do not release** the IP.
-- **Release** happens only when the `IPAMClaim` itself is deleted (which
-`ipam-extensions` triggers when the VM is deleted).
+- **Release** happens when the `IPAMClaim` itself is gone — observed by a
+**level-driven** reconcile against live claims, not only by a delete event
+(`ipam-extensions` deletes the claim when the VM is deleted).
+
+`IPAMClaim.status.ips`, `IPPool.Spec.Allocations`, and (when enabled)
+`OverlappingRangeIPReservation` must stay in sync. Drift is a first-class
+reconcile problem, not a write-once side effect. See
+[Keeping the CRs in sync](#keeping-the-crs-in-sync).
 
 ## Design
 
@@ -123,45 +130,105 @@ wiring keeps the claim on the pod annotation. Whereabouts therefore:
    top-level net field, or `args.cni`) — useful for tests and future Multus
    injection.
 2. If still empty, **resolves the claim from the pod's network-selection
-   annotation** via the Kubernetes API (`pkg/ipamclaim.ResolveFromPodAnnotation`),
-   matching on interface name and/or network name.
+   annotation** via the Kubernetes API, matching on interface name and/or network
+   name.
 
-Claim namespace defaults to the pod namespace.
+`ipam-claim-reference` is a **claim name only**. Empty or malformed values are
+ignored (legacy pod-scoped allocation). Cross-namespace names (`ns/name`) are
+rejected.
+
+### Claim namespace
+
+The claim is always in the **workload (pod) namespace**. There is no
+`IPAMClaimNamespace` config field and no cross-namespace lookup.
+
+This matches `ipam-extensions` (the claim is owned by the VM in the same
+namespace as the `virt-launcher` pod) and avoids a pod in namespace A pinning
+allocations owned by a claim in namespace B.
+
+Reservations still record `namespace/name` because `IPPool` objects live in the
+Whereabouts namespace, not the pod namespace.
+
+### Keeping the CRs in sync
+
+Three objects describe the same lease:
+
+| Object | Role |
+| ------ | ---- |
+| `IPPool.Spec.Allocations` | **Authoritative lease.** An IP is allocated iff it appears here. |
+| `OverlappingRangeIPReservation` | Same lease, when overlapping ranges are enabled. Must not diverge from the pool row. |
+| `IPAMClaim.status.ips` | **Claim intent.** The addresses this claim must keep across pod recreate. Written only after a successful pool (and overlapping) reservation. |
+
+**Write order (CNI ADD):** reserve in `IPPool` (and overlapping CR) first, tagged
+with the claim identity then patch `status.ips` / `ownerPod`. A crash between
+those steps leaves a claim-tagged reservation with empty `status.ips`, which
+reconcile heals by completing the status write — never by freeing the IP while
+the claim still exists.
+
+**Reuse (CNI ADD with populated `status.ips`):** validate network, interface,
+address family, and pool membership. Atomically take over each address only if it
+is free or already owned by **this** claim (match on `IPAMClaimRef`,
+`namespace/name`). Resource-version conflicts retry. Never steal an IP owned by
+a different live claim.
+
+**Reconcile (level-driven, not only delete events):** periodically, and on
+informer resync / claim add-update-delete, walk claim-tagged pool and overlapping
+rows and compare them to live `IPAMClaim` objects:
+
+- Claim **NotFound** → free the pool row **and** the overlapping CR.
+- Claim **lookup error** (timeout, conflict, unavailable) → **retry do not
+  release**.
+- Claim exists, IP is in `status.ips`, pool row missing or untagged → re-reserve
+  if free or already owned by this claim otherwise set a claim condition and do
+  not steal.
+- Claim exists, pool row tagged for this claim, IP **not** in `status.ips` →
+  treat as incomplete persist write the IP into `status.ips` rather than free.
+- Overlapping CR missing or pointing at the wrong `PodRef` while the pool row is
+  claim-owned → create/update the overlapping CR to match. Never leave overlapping
+  state that would reject a later take-over.
+
+A repair must never transfer an IP that another live claim already owns.
+
+**Claim identity on every reservation:** `IPAMClaimRef` (`<pod-namespace>/<claim-name>`).
+Assignment, deallocation, overlapping-range conflict checks, and GC compare this
+identity, not `PodRef` alone. Existing pod-only rows stay pod-scoped (empty
+claim fields).
 
 ### Changes in Modules
-
-As implemented in [#742](https://github.com/k8snetworkplumbingwg/whereabouts/pull/742):
 
 1. `go.mod` — add `github.com/k8snetworkplumbingwg/ipamclaims` (API types + clientset).
 2. `pkg/types/types.go` — extend `IPAMConfig` / `Net` / `IPReservation`:
    ```go
-   IPAMClaimReference string // name of the IPAMClaim, empty => legacy behavior
-   IPAMClaimNamespace string // usually the pod namespace
+   IPAMClaimReference string // claim *name* only namespace is the pod namespace
    IPAMClaimRef       string // on reservations: "namespace/name"
    ```
-3. `pkg/ipamclaim/` — claim reference resolution (CNI args + pod NSE), claim fetch,
-   and `status.ips` / `ownerPod` persistence.
-4. `pkg/config/config.go` (`LoadIPAMConfig`) — populate claim fields from CNI stdin
-   sources when present. No behavior change when empty.
-5. `pkg/allocate/allocate.go` (`AssignIPForClaim`) — reuse by claim ref / preferred
-   IPs (idempotent take-over for stop/start and migration handoff) tag new
-   reservations with `IPAMClaimRef`.
-6. `pkg/api/...` + CRDs — dedicated `ipamclaimref` on `IPAllocation` and
+   No `IPAMClaimNamespace` field on config.
+3. `pkg/ipamclaim/` — claim reference resolution (CNI args + pod NSE), claim fetch
+   in the pod namespace, and `status.ips` / `ownerPod` persistence.
+4. `pkg/config/config.go` (`LoadIPAMConfig`) — populate the claim **name** from CNI
+   stdin sources when present. No behavior change when empty.
+5. `pkg/allocate/allocate.go` (`AssignIPForClaim`) — reuse by claim identity /
+   preferred IPs (idempotent take-over for stop/start and migration handoff) tag
+   new reservations with `IPAMClaimRef`.
+6. `pkg/api/...` + CRDs — `ipamclaimref` on `IPAllocation` and
    `OverlappingRangeIPReservationSpec` (does **not** overload `PodRef`).
 7. `pkg/storage/kubernetes/ipam.go` — claim-aware Allocate / Deallocate:
-   - Resolve claim, fetch `IPAMClaim`, reuse or allocate, persist status.
+   - Resolve claim in the pod namespace, reuse or allocate, persist status after
+     the pool/overlapping write.
    - Skip freeing claim-backed reservations on Deallocate.
-   - Overlapping-range create treats AlreadyExists as claim take-over (update
-     PodRef / IfName / IPAMClaimRef).
-8. `pkg/controlloop` — `ClaimController` watches IPAMClaim **delete** and frees
-   matching pool / overlapping reservations. `garbageCollectPodIPs` skips any
-   reservation with non-empty `IPAMClaimRef` (release is claim-delete only).
-9. `pkg/reconciler` — orphan GC also skips claim-backed reservations.
+   - Overlapping-range create treats AlreadyExists as claim take-over when the
+     existing row is owned by the same `IPAMClaimRef` (update `PodRef` / `IfName`).
+8. `pkg/controlloop` — **level-driven** claim reconcile: compare claim-tagged
+   pool and overlapping reservations to live `IPAMClaim` objects (add/update/delete
+   **and** periodic/resync). `garbageCollectPodIPs` skips any reservation with
+   non-empty `IPAMClaimRef` (release is claim-absence, not pod delete).
+9. `pkg/reconciler` — orphan GC uses the same live-claim check never frees on
+   lookup error.
 10. Install path — IPAMClaim CRD + RBAC for `ipamclaims` / `ipamclaims/status` in
     daemonset, Helm chart, and kind e2e setup.
-11. **Tests / docs** — unit tests (config, allocate, reference) e2e covers
-    allocate → retain across pod recreate → release on claim delete; user docs
-    (`doc/persistent-ips.md`) ship in #742. Live-migration e2e is not yet covered.
+11. **Tests / docs** — unit tests (config, allocate, drift repair, overlapping
+    take-over) e2e covers allocate → retain across pod recreate → release on
+    claim delete user docs (`doc/persistent-ips.md`).
 
 ### Lifecycle walk-through
 
@@ -176,20 +243,18 @@ As implemented in [#742](https://github.com/k8snetworkplumbingwg/whereabouts/pul
 
 ## Hard problems / remaining risks
 
-1. **Live migration overlap.** Source and target `virt-launcher` pods coexist and
-  share the claim's IP for a window. Implementation allows take-over of an
-  existing claim-backed reservation and preferred IPs from `status.ips`, and
-  updates overlapping reservations on AlreadyExists. Concurrent ADD under heavy
-  churn remains the main risk area e2e covers stop/start recreate, not full
-  KubeVirt migration yet.
-2. **Overlapping-range reservations** — addressed by tagging with `IPAMClaimRef`
-  and updating (not failing) when the same IP is re-acquired for a new pod.
+1. **Live migration overlap.** Source and target pods coexist and share the
+   claim's IP for a window. Take-over is allowed only for the same `IPAMClaimRef`.
+   Source DEL must not clear the target's reservation.
+2. **Overlapping-range reservations** — tagged with the same claim identity as
+   the pool row updated (not failed) on take-over included in drift reconcile.
 3. **Idempotency under churn** (old pod terminating while new pod starts) —
-  handled via claim-ref matching and preferred-IP take-over in `AssignIPForClaim`.
-4. **Stale reconciliation** — pod/reconciler GC never frees claim-backed rows
-  only the IPAMClaim-delete controller does. If that controller was down across
-  a claim delete, a restart + delete-event (or operator re-delete) is needed to
-  free orphans broader resync cleanup is a follow-up if needed.
+   handled via `IPAMClaimRef` matching and preferred-IP take-over.
+4. **Incomplete updates / drift** — pool-first writes plus level-driven
+   reconcile repair `status.ips` ↔ pool ↔ overlapping divergence without stealing
+   IPs owned by another live claim.
+5. **Controller downtime** — because cleanup is level-driven, a missed delete
+   event is healed on the next reconcile. Lookup errors never release.
 
 ## Delivery plan
 
@@ -219,11 +284,23 @@ change and full backwards compatibility.
 
 - **Reference transport** — Multus does not inject the NSE claim into delegate
   IPAM stdin today. Whereabouts accepts CNI/`args.cni` when present and otherwise
-  resolves `ipam-claim-reference` from the pod network-selection annotation
-  (same wiring as OVN-Kubernetes / ipam-extensions).
-- **Live-migration handoff** — reuse claim-backed pool reservations and
-  `status.ips` preferred addresses update `status.ownerPod` on ADD overlapping
-  AlreadyExists is treated as take-over. Full migration e2e remains a follow-up.
-- **Reservation tagging** — dedicated `IPAMClaimRef` / `ipamclaimref` field on
-  IPPool allocations and overlapping reservations (does not overload `PodRef`).
+  resolves `ipam-claim-reference` (claim **name**) from the pod network-selection
+  annotation (same wiring as OVN-Kubernetes / ipam-extensions).
+- **Claim namespace** — Pin to the workload (pod) namespace. Drop
+  `IPAMClaimNamespace` no cross-namespace claims.
+- **CR sync** — `IPPool.Spec.Allocations` is the authoritative lease
+  `IPAMClaim.status.ips` is the persisted claim set. Reconcile must detect and
+  repair drift, including incomplete pool-vs-status updates, and must never steal
+  an IP another live claim owns.
+- **Overlapping CR** — Same `IPAMClaimRef` (`namespace/name`) and the same
+  sync/repair rules as the pool row. Take-over updates the overlapping CR instead
+  of treating the target pod as a conflict.
+- **Live-migration handoff** — Target ADD reuses the claim IP source DEL does
+  not free it. `ownerPod` hands off overlapping AlreadyExists is take-over for
+  the same `IPAMClaimRef`.
+- **Level-driven cleanup** — Do not rely only on IPAMClaim delete events.
+  Reconcile claim-tagged reservations against live claims on resync/periodic
+  sync. API/informer errors are retryable and must not release.
+- **Reservation tagging** — Dedicated `IPAMClaimRef` on IPPool allocations and
+  overlapping reservations (does not overload `PodRef`).
 - **Implementation** — [whereabouts#742](https://github.com/k8snetworkplumbingwg/whereabouts/pull/742).

--- a/doc/proposals/persistent-ips-ipamclaims.md
+++ b/doc/proposals/persistent-ips-ipamclaims.md
@@ -1,0 +1,223 @@
+# Persistent IPs for KubeVirt VMs via the IPAMClaim standard
+
+Status: **Draft / for discussion** (targets whereabouts#557, whereabouts#500)
+
+This proposal describes how Whereabouts can implement the multi-network de-facto
+standard `IPAMClaim` contract so that KubeVirt VirtualMachines keep a stable IP
+across stop/start and live migration — the same capability OVN-Kubernetes already
+provides through `[kubevirt/ipam-extensions](https://github.com/kubevirt/ipam-extensions)`
+and the `[ipamclaims](https://github.com/k8snetworkplumbingwg/ipamclaims)` CRD — **without**
+requiring OVN-Kubernetes and **without** any KubeVirt core API change.
+
+# Table of contents
+
+- [Introduction](#introduction)
+  - [Goal](#goal-of-this-proposal)
+  - [Non-goals](#non-goals)
+- [Background: how allocation works today](#background-how-allocation-works-today)
+- [The IPAMClaim contract](#the-ipamclaim-contract)
+- [Design](#design)
+  - [How the claim reference reaches Whereabouts](#how-the-claim-reference-reaches-whereabouts)
+  - [Changes in Modules](#changes-in-modules)
+  - [Lifecycle walk-through](#lifecycle-walk-through)
+- [Hard problems / open questions](#hard-problems--open-questions)
+- [Delivery plan](#delivery-plan)
+- [Summary](#summary)
+- [Discussions and Decisions](#discussions-and-decisions)
+
+
+
+## Introduction
+
+When a KubeVirt VM uses a Multus secondary network backed by Whereabouts IPAM
+(e.g. `bridge` + `whereabouts`), the guest IP is tied to the lifecycle of the
+`virt-launcher` **pod**. On VM stop/start or live migration the pod is recreated,
+Whereabouts' IP-control-loop garbage-collects the allocation, and the VM comes back
+with a different address. This breaks workloads that assume a stable IP (DNS,
+firewall rules, clustering, licensing).
+
+Upstream KubeVirt has intentionally chosen **not** to solve this in KubeVirt core.
+Instead, persistent VM IPs are handled at the IPAM layer through the `IPAMClaim`
+CRD: a controller (`ipam-extensions`) creates an `IPAMClaim` owned by the VM, and
+the IPAM plugin persists the allocation against that claim rather than against the
+pod. OVN-Kubernetes already honors these claims Whereabouts does not yet.
+
+### Goal of this proposal
+
+- Allow a KubeVirt VM interface backed by Whereabouts to retain the **same IP**
+across VM stop/start and live migration.
+- Do so by implementing the existing `IPAMClaim` standard, so the solution
+interoperates with `ipam-extensions` and requires no new Whereabouts-specific
+API and no changes to KubeVirt.
+- Remain fully backwards compatible: pods without a claim reference behave exactly
+as today.
+
+
+
+### Non-goals
+
+- Creating or deleting `IPAMClaim` resources. That is `ipam-extensions`' job the
+claim is owned by the VM and its lifecycle is managed by the controller.
+- Persistent IPs for arbitrary (non-KubeVirt) pods, though the mechanism is generic.
+- Any change to KubeVirt core (a bespoke `persistIP` field was proposed in
+kubevirt/kubevirt#18636 and declined as out of scope for core — this proposal is
+the maintainer-recommended alternative).
+
+
+
+## Background: how allocation works today
+
+- The CNI entrypoint `cmd/whereabouts.go` (`cmdAdd`/`cmdDel`) calls
+`kubernetes.IPManagement(ctx, Allocate|Deallocate, config, client)` in
+`pkg/storage/kubernetes/ipam.go`.
+- An allocation's identity is the **pod**: `IPAMConfig.GetPodRef()` returns
+`"<namespace>/<podName>"` (`pkg/types/types.go`). Reservations are recorded in
+`IPPool.Spec.Allocations` (`map[index]IPAllocation{ContainerID, PodRef, IfName}`)
+and, when overlapping ranges are enabled, in `OverlappingRangeIPReservation` CRs.
+- The IP-control-loop (`pkg/controlloop/pod.go`, `garbageCollectPodIPs`) watches
+**Pod deletions** and frees any allocation whose `PodRef` matches the deleted pod.
+It already contains a StatefulSet special case: if a pod of the same
+name/namespace exists and is not being deleted, it skips the cleanup.
+
+The pod-centric identity plus delete-triggered GC is exactly why VM IPs do not
+persist. The claim gives us a **pod-independent identity** to anchor the allocation to.
+
+## The IPAMClaim contract
+
+From `k8snetworkplumbingwg/ipamclaims` (`k8s.cni.cncf.io/v1alpha1`):
+
+```go
+type IPAMClaimSpec struct {
+    Network   string // network name the allocation belongs to
+    Interface string // pod interface name
+}
+
+type IPAMClaimStatus struct {
+    IPs        []string           // allocated addresses (v4, v6)
+    OwnerPod   *OwnerPod          // { Name string } — pod currently holding the claim
+    Conditions []metav1.Condition
+}
+```
+
+Expected plugin behavior:
+
+- **CNI ADD**: if the referenced claim's `status.ips` is non-empty, **reuse** those
+addresses. Otherwise allocate normally and **write** `status.ips` (and set
+`status.ownerPod`).
+- **CNI DEL**: if the allocation is claim-backed, **do not release** the IP.
+- **Release** happens only when the `IPAMClaim` itself is deleted (which
+`ipam-extensions` triggers when the VM is deleted).
+
+
+
+## Design
+
+
+
+### How the claim reference reaches Whereabouts
+
+`ipam-extensions` adds an `ipam-claim-reference` attribute to the VM pod's
+`k8s.v1.cni.cncf.io/networks` network-selection element for the eligible interface,
+and Multus forwards network-selection-element attributes to the delegate plugin.
+
+> **Open item to confirm before PR1:** the exact transport by which the reference
+> reaches the delegate IPAM plugin — a top-level field injected into the delegate
+> CNI config, `RuntimeConfig`, or `CNI_ARGS`. We will mirror whatever OVN-Kubernetes
+> reads (it is the reference implementation) so Whereabouts is drop-in compatible
+> with the same `ipam-extensions`/Multus wiring.
+
+
+
+### Changes in Modules
+
+1. `go.mod` **/ vendor** — add `github.com/k8snetworkplumbingwg/ipamclaims`
+  (API types + generated clientset).
+2. `pkg/types/types.go` — extend `IPAMConfig`:
+  ```go
+   IPAMClaimReference string // name of the IPAMClaim, empty => legacy behavior
+   IPAMClaimNamespace string // usually the pod namespace
+  ```
+3. `pkg/config/config.go` **(**`LoadIPAMConfig`**)** — populate the fields above from
+  the transport confirmed in the open item. No behavior change when empty.
+4. `pkg/storage/kubernetes/ipam.go` **(**`IPManagement`**,** `Allocate` **branch)** —
+  claim-aware allocation:
+  - Fetch the `IPAMClaim`.
+  - `len(status.ips) > 0` → reuse those IPs reserve them **idempotently** (a repeat
+  reservation for the same claim is a success, not a conflict).
+  - else → allocate as today, then patch `status.ips` + `status.ownerPod`.
+  - Tag the pool/overlapping reservation so it is recognizable as claim-backed
+  (e.g. store the claim ref alongside `PodRef`).
+5. `pkg/storage/kubernetes/ipam.go` **(**`Deallocate` **branch)** — if the reservation
+  is claim-backed, skip freeing the address (optionally clear `ownerPod`) keep the
+   reservation intact so the next pod re-acquires the same IP.
+6. `pkg/controlloop` — release on claim deletion, not pod deletion:
+  - Add an `IPAMClaim` informer on **delete**, free the claim's reserved IPs via
+   the existing `Deallocate` cleanup path.
+  - In `garbageCollectPodIPs`, skip GC for a claim-backed allocation whose claim
+  still exists (a generalization of the current StatefulSet guard).
+7. **Tests** — unit tests for config parsing, reuse-vs-allocate, and DEL-no-release
+  an `e2e/` scenario exercising VM stop/start and (ideally) migration.
+
+
+
+### Lifecycle walk-through
+
+
+| Event                  | Actor                         | Result                                                                                                       |
+| ---------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| VM created             | ipam-extensions               | Creates `IPAMClaim` (empty `status.ips`), owned by the VM injects `ipam-claim-reference` on the launcher pod |
+| Pod ADD (first boot)   | Whereabouts                   | `status.ips` empty → allocate, write `status.ips`, set `ownerPod`                                            |
+| VM stop → pod DEL      | Whereabouts                   | Claim-backed → **keep** the IP control-loop **skips** GC because the claim still exists                      |
+| VM start → new pod ADD | Whereabouts                   | `status.ips` populated → **reuse** the same IP                                                               |
+| Live migration         | Whereabouts                   | Target pod ADD reuses the claim IP while source still holds it `ownerPod` hands off                          |
+| VM deleted             | ipam-extensions → Whereabouts | `IPAMClaim` deleted → control-loop **frees** the IP                                                          |
+
+
+
+
+## Hard problems / open questions
+
+1. **Live migration overlap.** Source and target `virt-launcher` pods coexist and
+  share the claim's IP for a window. The target must be allowed to reuse the IP
+   while the source reservation still exists `status.ownerPod` mediates the handoff.
+   This is the primary concurrency risk and needs explicit review.
+2. **Overlapping-range reservations** are pod-keyed today re-acquiring the same IP
+  for a new pod must not be treated as a duplicate/conflict.
+3. **Idempotency under churn** (old pod terminating while new pod starts).
+4. **Stale reconciliation** — if the control-loop was down when a claim was deleted,
+  the informer resync must free orphaned reservations.
+5. **Reference transport** — the one item to confirm against OVN-Kubernetes/Multus
+  (see above) before locking the config parsing.
+
+
+
+## Delivery plan
+
+
+| PR  | Scope                                                                         | Risk   |
+| --- | ----------------------------------------------------------------------------- | ------ |
+| PR0 | This design note align at a community meeting                                 | none   |
+| PR1 | Vendor `ipamclaims` add `IPAMClaimReference` + config parsing (inert)         | low    |
+| PR2 | Allocate path: reuse existing / persist new `status.ips`                      | medium |
+| PR3 | Deallocate path: do not release claim-backed IPs on pod DEL                   | medium |
+| PR4 | Control-loop: IPAMClaim-delete watcher + skip GC for claim-backed allocations | medium |
+| PR5 | e2e (stop/start + migration) and docs                                         | low    |
+
+
+
+
+## Summary
+
+Anchor persistent allocations to the `IPAMClaim` (pod-independent, VM-owned) instead
+of the pod. On ADD, reuse `status.ips` when present else allocate and persist them
+on pod DEL, keep claim-backed IPs release only when the claim is deleted. This makes
+Whereabouts interoperable with the existing `ipam-extensions`/`IPAMClaim` machinery,
+delivering persistent VM IPs on non-OVN-Kubernetes clusters with no KubeVirt API
+change and full backwards compatibility.
+
+## Discussions and Decisions
+
+- *TBD* — reference-transport mechanism confirmed against OVN-Kubernetes.
+- *TBD* — live-migration handoff semantics (`ownerPod`) agreed with maintainers.
+- *TBD* — whether reservation records gain a dedicated claim field or overload `PodRef`.
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->

**What this PR does / why we need it**:
Adds a draft design proposal for implementing the `IPAMClaim` contract in Whereabouts so KubeVirt VMs on Multus secondary networks can retain a stable IP across stop/start and live migration.

Today allocations are pod-scoped, so the IP control-loop frees them when the `virt-launcher` pod is deleted and the VM comes back with a different address. This proposal describes claim-aware ADD/DEL and control-loop behavior (reuse `status.ips`, skip release on pod DEL, free only on claim deletion), aligned with `ipam-extensions` / `OVN-Kubernetes`, with no KubeVirt core API change and full backwards compatibility when no claim is present.

This is PR0 (design for discussion) ahead of the incremental implementation PRs outlined in the delivery plan.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #557, Fixes #500

**Special notes for your reviewer** *(optional)*:

- Docs-only, no code changes.
- Please review the module change list and delivery plan (PR1–PR5) for sequencing and risk.
- Goal is community alignment before coding starts.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the persistent IP address proposal with the proposed `IPAMClaim` contract.
  * Documented claim validation, deterministic claim resolution, and fail-closed handling of invalid or conflicting references.
  * Added details on reservation identity, claim-based IP retention, reconciliation, drift repair, stale reservation cleanup, and release behavior.
  * Clarified rollout requirements, implementation tracking, rollback considerations, and follow-up migration testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->