### PR TITLE
Fix false IPAM conf mismatch error when network_name is empty

### DIFF
--- a/pkg/node-controller/controller.go
+++ b/pkg/node-controller/controller.go
@@ -551,7 +551,7 @@ func (c *Controller) checkForMultiNadMismatch(name, namespace string) error {
 }
 
 func checkIpamConfMatch(conf1, conf2 *types.IPAMConfig) bool {
-	if conf1.NetworkName == conf2.NetworkName {
+	if conf1.NetworkName != "" && conf1.NetworkName == conf2.NetworkName {
 		return conf1.IPRanges[0].Range == conf2.IPRanges[0].Range && conf1.NodeSliceSize == conf2.NodeSliceSize
 	}
 	return true

--- a/pkg/node-controller/controller_test.go
+++ b/pkg/node-controller/controller_test.go
@@ -1029,6 +1029,35 @@ func TestTwoNetworksRangeAndSliceMismatch(t *testing.T) {
 	f.runExpectError(context.TODO(), getKey(nad2, t))
 }
 
+// TestEmptyNetworkNameDifferentRangesNoError verifies that two NADs with empty
+// network_name and different IP ranges are treated as independent networks.
+// Without the fix in checkIpamConfMatch, empty strings match ("" == "") and the
+// controller incorrectly reports an IPAM conf mismatch, blocking syncHandler.
+func TestEmptyNetworkNameDifferentRangesNoError(t *testing.T) {
+	f := newFixture(t)
+	nad1 := newNad("odf-cluster-nad", "", "192.168.7.0/26", "/28")
+	nad2 := newNad("odf-public-nad", "", "192.168.6.0/26", "/28")
+	node1 := newNode("node1")
+
+	f.nadLister = append(f.nadLister, nad1, nad2)
+	f.nadObjects = append(f.nadObjects, nad1, nad2)
+	f.nodeLister = append(f.nodeLister, node1)
+	f.kubeobjects = append(f.kubeobjects, node1)
+
+	nodeSlicePool := newNodeSlicePool("", "192.168.7.0/26", "/28",
+		v1alpha1.NodeSlicePoolStatus{
+			Allocations: []v1alpha1.NodeSliceAllocation{
+				{NodeName: "node1", SliceRange: "192.168.7.0/28"},
+				{NodeName: "", SliceRange: "192.168.7.16/28"},
+				{NodeName: "", SliceRange: "192.168.7.32/28"},
+				{NodeName: "", SliceRange: "192.168.7.48/28"},
+			},
+		}, nad1)
+	f.expectNodeSlicePoolCreateAction(nodeSlicePool)
+
+	f.run(context.TODO(), getKey(nad1, t))
+}
+
 func getKey(nad *k8snetplumbersv1.NetworkAttachmentDefinition, t *testing.T) string {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(nad)
 	if err != nil {


### PR DESCRIPTION
Fixes spurious `found IPAM conf mismatch` error when multiple NADs use whereabouts IPAM with empty network_name. The `empty-string equality "" == ""` incorrectly groups unrelated NADs as the same network, blocking `syncHandler` in a permanent requeue loop.

### Root Cause
When multiple NADs use whereabouts IPAM with an empty network_name, checkIpamConfMatch treats them as sharing the same network because "" == "" evaluates to true. This causes a spurious "found IPAM conf mismatch" error that blocks syncHandler and requeues indefinitely.

### Fix
Add `conf1.NetworkName != ""` guard in `checkIpamConfMatch` so NADs without an explicit network_name are treated as independent networks.

### Before fix 
```bash
  E0810 08:45:32.274329  1 controller.go:290] "Unhandled Error" err="error syncing 'default/odf-cluster-nad': found IPAM conf mismatch for network-attachment-definitions with same network
  name, requeuing"
  E0810 08:45:32.274583  1 controller.go:290] "Unhandled Error" err="error syncing 'default/odf-public-nad': found IPAM conf mismatch for network-attachment-definitions with same network
  name, requeuing"
  E0810 08:45:32.280308  1 controller.go:290] "Unhandled Error" err="error syncing 'default/odf-cluster-nad': found IPAM conf mismatch for network-attachment-definitions with same network
  name, requeuing"
  E0810 08:45:32.280570  1 controller.go:290] "Unhandled Error" err="error syncing 'default/odf-public-nad': found IPAM conf mismatch for network-attachment-definitions with same network
  name, requeuing"
  Both NADs stuck in infinite requeue — never reaches "Successfully synced".
```

### After fix 
```bash
  I0810 08:42:54.300025  1 controller.go:352] "skipping update node slices for network-attachment-definition due missing node slice or range configurations"
  resourceName="default/odf-cluster-nad"
  I0810 08:42:54.300038  1 controller.go:285] "Successfully synced" resourceName="default/odf-cluster-nad"
  I0810 08:42:54.306021  1 controller.go:352] "skipping update node slices for network-attachment-definition due missing node slice or range configurations"
  resourceName="default/odf-public-nad"
  I0810 08:42:54.306029  1 controller.go:285] "Successfully synced" resourceName="default/odf-public-nad"
  Both NADs sync cleanly, zero mismatch errors.
```
  
### Test
  - Added `TestEmptyNetworkNameDifferentRangesNoError`
  - Full suite: 15/15 pass, zero regressions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network configuration matching by requiring a non-empty, matching network name.
  * Prevented configurations with empty network names and different IP ranges from being incorrectly treated as mismatches.
  * Improved synchronization for independent network attachment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->