### PR TITLE
Fix kind e2e setup on macOS and Apple Silicon

### DIFF
--- a/hack/cni-install.yml
+++ b/hack/cni-install.yml
@@ -12,7 +12,10 @@ data:
     case "$ARCH" in
       x86_64|amd64) CNI_TGZ="cni-plugins-linux-amd64-v1.1.1.tgz" ;;
       aarch64|arm64) CNI_TGZ="cni-plugins-linux-arm64-v1.1.1.tgz" ;;
-      *) CNI_TGZ="cni-plugins-linux-amd64-v1.1.1.tgz" ;;
+      *)
+        echo "unsupported architecture: ${ARCH}" >&2
+        exit 1
+        ;;
     esac
     wget "https://github.com/containernetworking/plugins/releases/download/v1.1.1/${CNI_TGZ}"
     cd /host/opt/cni/bin

--- a/hack/cni-install.yml
+++ b/hack/cni-install.yml
@@ -7,9 +7,16 @@ metadata:
 data:
   install_cni.sh: |
     cd /tmp
-    wget https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-amd64-v1.1.1.tgz
+    # Install the correct CNI plugin binaries for the node architecture.
+    ARCH="$(uname -m)"
+    case "$ARCH" in
+      x86_64|amd64) CNI_TGZ="cni-plugins-linux-amd64-v1.1.1.tgz" ;;
+      aarch64|arm64) CNI_TGZ="cni-plugins-linux-arm64-v1.1.1.tgz" ;;
+      *) CNI_TGZ="cni-plugins-linux-amd64-v1.1.1.tgz" ;;
+    esac
+    wget "https://github.com/containernetworking/plugins/releases/download/v1.1.1/${CNI_TGZ}"
     cd /host/opt/cni/bin
-    tar xvfzp /tmp/cni-plugins-linux-amd64-v1.1.1.tgz
+    tar xvfzp "/tmp/${CNI_TGZ}"
     sleep infinite
 ---
 apiVersion: apps/v1
@@ -29,8 +36,6 @@ spec:
         name: cni-plugins
     spec:
       hostNetwork: true
-      nodeSelector:
-        kubernetes.io/arch: amd64
       tolerations:
       - operator: Exists
         effect: NoSchedule

--- a/hack/e2e-setup-kind-cluster.sh
+++ b/hack/e2e-setup-kind-cluster.sh
@@ -13,8 +13,22 @@ while true; do
   esac
 done
 
-HERE="$(dirname "$(readlink --canonicalize ${BASH_SOURCE[0]})")"
-ROOT="$(readlink --canonicalize "$HERE/..")"
+# macOS/BSD `readlink` does not support GNU `--canonicalize`, so compute paths
+# portably using `realpath` (preferred) or Python.
+HERE="$(
+  if command -v realpath >/dev/null 2>&1; then
+    dirname "$(realpath "${BASH_SOURCE[0]}")"
+  else
+    dirname "$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "${BASH_SOURCE[0]}")"
+  fi
+)"
+ROOT="$(
+  if command -v realpath >/dev/null 2>&1; then
+    realpath "$HERE/.."
+  else
+    python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$HERE/.."
+  fi
+)"
 MULTUS_DAEMONSET_URL="https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/master/deployments/multus-daemonset.yml"
 CNIS_DAEMONSET_PATH="$ROOT/hack/cni-install.yml"
 TIMEOUT_K8="5000s"


### PR DESCRIPTION
Use portable path canonicalization instead of GNU readlink, and install architecture-matched CNI plugins so arm64 kind nodes get macvlan.

Fixes #740

<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CNI installation now supports matching plugins for amd64 and arm64 nodes.
  * Unsupported node architectures now produce a clear error instead of using an incompatible plugin.

* **Bug Fixes**
  * Improved cluster setup compatibility across environments by using portable path-resolution methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->