### PR TITLE
Add IPAMClaim backed persistent IPs for KubeVirt stop/start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ bin/
 #Claude 
 CLAUDE.local.md
 ./claude
+
+e2e/.env

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ kubectl apply \
     -f doc/crds/daemonset-install.yaml \
     -f doc/crds/whereabouts.cni.cncf.io_ippools.yaml \
     -f doc/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml \
+    -f doc/crds/k8s.cni.cncf.io_ipamclaims.yaml \
     -f doc/crds/reconciler-deployment.yaml
 ```
 
@@ -224,6 +225,34 @@ You must run your whereabouts daemonset, whereabouts controller in the same name
 The field in the example `node_slice_size` determines how large of a CIDR to allocate per node and the existence of the field is what triggers
 `Fast IPAM` mode.
 
+## Persistent IPs (IPAMClaim)
+
+Whereabouts can retain the same IP across pod recreation by tying the allocation
+to an [`IPAMClaim`](https://github.com/k8snetworkplumbingwg/ipamclaims). This is
+the recommended way to give KubeVirt VMs stable addresses on Multus secondary
+networks that use Whereabouts (interoperable with
+[`kubevirt/ipam-extensions`](https://github.com/kubevirt/ipam-extensions)).
+
+Install the CRD if you have not already:
+
+```bash
+kubectl apply -f doc/crds/k8s.cni.cncf.io_ipamclaims.yaml
+```
+
+Reference the claim from the Multus network-selection element:
+
+```yaml
+annotations:
+  k8s.v1.cni.cncf.io/networks: |
+    [{
+      "name": "wa-nad",
+      "interface": "net1",
+      "ipam-claim-reference": "my-claim"
+    }]
+```
+
+Pods without a claim behave as before. See [doc/persistent-ips.md](doc/persistent-ips.md)
+for lifecycle details, a full manual example, and KubeVirt notes.
 
 ## Core Parameters
 

--- a/cmd/controlloop/controlloop.go
+++ b/cmd/controlloop/controlloop.go
@@ -16,6 +16,8 @@ import (
 
 	nadclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned"
 	nadinformers "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/informers/externalversions"
+	ipamclaimsclient "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1/apis/clientset/versioned"
+	ipamclaimsinformers "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1/apis/informers/externalversions"
 
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/controlloop"
 	wbclient "github.com/k8snetworkplumbingwg/whereabouts/pkg/generated/clientset/versioned"
@@ -55,8 +57,16 @@ func main() {
 		os.Exit(couldNotCreateController)
 	}
 
+	claimController, err := newClaimController(stopChan)
+	if err != nil {
+		_ = logging.Errorf("could not create the IPAMClaim controller: %v", err)
+		os.Exit(couldNotCreateController)
+	}
+
 	networkController.Start(stopChan)
 	defer networkController.Shutdown()
+	claimController.Start(stopChan)
+	defer claimController.Shutdown()
 
 	<-stopChan
 	logging.Verbosef("shutting down network controller")
@@ -117,6 +127,40 @@ func newPodController(stopChannel chan struct{}) (*controlloop.PodController, er
 	netAttachDefInformerFactory.Start(stopChannel)
 	ipPoolInformerFactory.Start(stopChannel)
 	logging.Verbosef("Informer factories started")
+
+	return controller, nil
+}
+
+func newClaimController(stopChannel chan struct{}) (*controlloop.ClaimController, error) {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to implicitly generate the kubeconfig: %w", err)
+	}
+
+	wbClientSet, err := wbclient.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	claimsClientSet, err := ipamclaimsclient.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the IPAMClaims client: %w", err)
+	}
+
+	const noResyncPeriod = 0
+	ipPoolInformerFactory := wbinformers.NewSharedInformerFactory(wbClientSet, noResyncPeriod)
+	claimsInformerFactory := ipamclaimsinformers.NewSharedInformerFactory(claimsClientSet, noResyncPeriod)
+
+	controller := controlloop.NewClaimController(
+		wbClientSet,
+		claimsClientSet,
+		ipPoolInformerFactory,
+		claimsInformerFactory,
+	)
+	logging.Verbosef("IPAMClaim controller created")
+
+	ipPoolInformerFactory.Start(stopChannel)
+	claimsInformerFactory.Start(stopChannel)
 
 	return controller, nil
 }

--- a/cmd/whereabouts_test.go
+++ b/cmd/whereabouts_test.go
@@ -57,7 +57,7 @@ func AllocateAndReleaseAddressesTest(ipRange string, gw string, kubeconfigPath s
 	wbClient := *kubernetes.NewKubernetesClient(
 		fake.NewSimpleClientset(
 			ipPool(conf.IPRanges[0].Range, podNamespace, ipamNetworkName)),
-		fakek8sclient.NewSimpleClientset())
+		fakek8sclient.NewSimpleClientset(), nil)
 
 	for i := 0; i < len(expectedAddresses); i++ {
 		name := fmt.Sprintf("%s-%d", podName, i)
@@ -163,7 +163,7 @@ var _ = Describe("Whereabouts operations", func() {
 			fake.NewSimpleClientset(
 				ipPool(ipamConf.IPRanges[0].Range, podNamespace, ipamNetworkName, []whereaboutstypes.IPReservation{
 					{PodRef: ipamConf.GetPodRef(), IfName: ifname, IP: net.ParseIP(expectedAddress)}, {PodRef: "test"}}...)),
-			fakek8sclient.NewSimpleClientset())
+			fakek8sclient.NewSimpleClientset(), nil)
 
 		cniConf, err := newCNINetConf(cniVersion, ipamConf)
 		Expect(err).NotTo(HaveOccurred())
@@ -926,7 +926,7 @@ var _ = Describe("Whereabouts operations", func() {
 		wbClient := *kubernetes.NewKubernetesClient(
 			fake.NewSimpleClientset(
 				ipPool(ipamConf.IPRanges[0].Range, podNamespace, ipamConf.NetworkName)),
-			fakek8sclient.NewSimpleClientset())
+			fakek8sclient.NewSimpleClientset(), nil)
 
 		// allocate 8 IPs (192.168.1.5 - 192.168.1.12); the entirety of the pool defined above
 		for i := 0; i < 8; i++ {
@@ -997,7 +997,7 @@ var _ = Describe("Whereabouts operations", func() {
 		wbClient := *kubernetes.NewKubernetesClient(
 			fake.NewSimpleClientset(
 				ipPool(firstRange, podNamespace, ""), ipPool(secondRange, podNamespace, "")),
-			fakek8sclient.NewSimpleClientset())
+			fakek8sclient.NewSimpleClientset(), nil)
 
 		// ----------------------------- range 1
 
@@ -1120,7 +1120,7 @@ var _ = Describe("Whereabouts operations", func() {
 		wbClient := *kubernetes.NewKubernetesClient(
 			fake.NewSimpleClientset(
 				ipPool(firstRange, podNamespace, ""), ipPool(secondRange, podNamespace, "")),
-			fakek8sclient.NewSimpleClientset())
+			fakek8sclient.NewSimpleClientset(), nil)
 
 		// ----------------------------- range 1
 
@@ -1243,7 +1243,7 @@ var _ = Describe("Whereabouts operations", func() {
 		wbClient := *kubernetes.NewKubernetesClient(
 			fake.NewSimpleClientset(
 				ipPool(firstRange, podNamespace, ""), ipPool(secondRange, podNamespace, "")),
-			fakek8sclient.NewSimpleClientset())
+			fakek8sclient.NewSimpleClientset(), nil)
 
 		// ----------------------------- range 1
 
@@ -1367,7 +1367,7 @@ func newK8sIPAM(containerID, ifName string, ipamConf *whereaboutstypes.IPAMConfi
 	if err != nil {
 		return nil
 	}
-	k8sIPAM.Client = *kubernetes.NewKubernetesClient(wbClient, k8sCoreClient)
+	k8sIPAM.Client = *kubernetes.NewKubernetesClient(wbClient, k8sCoreClient, nil)
 	return k8sIPAM
 }
 

--- a/deployment/whereabouts-chart/crds/k8s.cni.cncf.io_ipamclaims.yaml
+++ b/deployment/whereabouts-chart/crds/k8s.cni.cncf.io_ipamclaims.yaml
@@ -1,0 +1,133 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: ipamclaims.k8s.cni.cncf.io
+spec:
+  group: k8s.cni.cncf.io
+  names:
+    kind: IPAMClaim
+    listKind: IPAMClaimList
+    plural: ipamclaims
+    singular: ipamclaim
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IPAMClaim is the Schema for the IPAMClaim API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              interface:
+                description: The pod interface name for which this allocation was
+                  created
+                type: string
+              network:
+                description: The network name for which this persistent allocation
+                  was created
+                type: string
+            required:
+            - interface
+            - network
+            type: object
+          status:
+            description: IPAMClaimStatus contains the observed status of the IPAMClaim.
+            properties:
+              conditions:
+                description: Conditions contains details for one aspect of the current
+                  state of this API Resource
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              ips:
+                description: The list of IP addresses (v4, v6) that were allocated
+                  for the pod interface
+                items:
+                  type: string
+                type: array
+              ownerPod:
+                description: The name of the pod holding the IPAMClaim
+                properties:
+                  name:
+                    type: string
+                type: object
+            required:
+            - ips
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deployment/whereabouts-chart/crds/whereabouts.cni.cncf.io_ippools.yaml
+++ b/deployment/whereabouts-chart/crds/whereabouts.cni.cncf.io_ippools.yaml
@@ -48,6 +48,11 @@ spec:
                       type: string
                     ifname:
                       type: string
+                    ipamclaimref:
+                      description: |-
+                        IPAMClaimRef is "namespace/name" of the IPAMClaim that owns this
+                        allocation. Empty for legacy pod-scoped allocations.
+                      type: string
                     podref:
                       type: string
                   required:

--- a/deployment/whereabouts-chart/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
+++ b/deployment/whereabouts-chart/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
@@ -45,6 +45,11 @@ spec:
                 type: string
               ifname:
                 type: string
+              ipamclaimref:
+                description: |-
+                  IPAMClaimRef is "namespace/name" of the IPAMClaim that owns this
+                  reservation.
+                type: string
               podref:
                 type: string
             required:

--- a/deployment/whereabouts-chart/templates/cluster_role.yaml
+++ b/deployment/whereabouts-chart/templates/cluster_role.yaml
@@ -44,6 +44,16 @@ rules:
   - get
   - list
   - watch
+- apiGroups: ["k8s.cni.cncf.io"]
+  resources:
+  - ipamclaims
+  - ipamclaims/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
 - apiGroups:
   - ""
   - events.k8s.io

--- a/doc/crds/daemonset-install.yaml
+++ b/doc/crds/daemonset-install.yaml
@@ -65,6 +65,16 @@ rules:
     - get
     - list
     - watch
+- apiGroups: ["k8s.cni.cncf.io"]
+  resources:
+    - ipamclaims
+    - ipamclaims/status
+  verbs:
+    - get
+    - list
+    - watch
+    - update
+    - patch
 - apiGroups:
   - ""
   - events.k8s.io

--- a/doc/crds/k8s.cni.cncf.io_ipamclaims.yaml
+++ b/doc/crds/k8s.cni.cncf.io_ipamclaims.yaml
@@ -1,0 +1,133 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: ipamclaims.k8s.cni.cncf.io
+spec:
+  group: k8s.cni.cncf.io
+  names:
+    kind: IPAMClaim
+    listKind: IPAMClaimList
+    plural: ipamclaims
+    singular: ipamclaim
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IPAMClaim is the Schema for the IPAMClaim API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              interface:
+                description: The pod interface name for which this allocation was
+                  created
+                type: string
+              network:
+                description: The network name for which this persistent allocation
+                  was created
+                type: string
+            required:
+            - interface
+            - network
+            type: object
+          status:
+            description: IPAMClaimStatus contains the observed status of the IPAMClaim.
+            properties:
+              conditions:
+                description: Conditions contains details for one aspect of the current
+                  state of this API Resource
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              ips:
+                description: The list of IP addresses (v4, v6) that were allocated
+                  for the pod interface
+                items:
+                  type: string
+                type: array
+              ownerPod:
+                description: The name of the pod holding the IPAMClaim
+                properties:
+                  name:
+                    type: string
+                type: object
+            required:
+            - ips
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/doc/crds/whereabouts.cni.cncf.io_ippools.yaml
+++ b/doc/crds/whereabouts.cni.cncf.io_ippools.yaml
@@ -48,6 +48,11 @@ spec:
                       type: string
                     ifname:
                       type: string
+                    ipamclaimref:
+                      description: |-
+                        IPAMClaimRef is "namespace/name" of the IPAMClaim that owns this
+                        allocation. Empty for legacy pod-scoped allocations.
+                      type: string
                     podref:
                       type: string
                   required:

--- a/doc/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
+++ b/doc/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml
@@ -45,6 +45,11 @@ spec:
                 type: string
               ifname:
                 type: string
+              ipamclaimref:
+                description: |-
+                  IPAMClaimRef is "namespace/name" of the IPAMClaim that owns this
+                  reservation.
+                type: string
               podref:
                 type: string
             required:

--- a/doc/persistent-ips.md
+++ b/doc/persistent-ips.md
@@ -1,0 +1,102 @@
+# Persistent IPs with IPAMClaim
+
+Whereabouts can keep the same IP across pod recreation by anchoring the
+allocation to an [`IPAMClaim`](https://github.com/k8snetworkplumbingwg/ipamclaims)
+instead of the pod. This is the same contract OVN-Kubernetes uses for
+KubeVirt VMs (via [`kubevirt/ipam-extensions`](https://github.com/kubevirt/ipam-extensions)).
+
+When no claim is referenced, behavior is unchanged: IPs are allocated and
+released with the pod lifecycle.
+
+## When to use this
+
+Use IPAMClaim-backed allocations when a workload must keep a stable address
+across stop/start or live migration — typically KubeVirt VirtualMachines on a
+Multus secondary network that uses Whereabouts IPAM.
+
+## Prerequisites
+
+1. Install the IPAMClaim CRD (shipped with Whereabouts for convenience):
+
+```bash
+kubectl apply -f doc/crds/k8s.cni.cncf.io_ipamclaims.yaml
+```
+
+2. Whereabouts DaemonSet RBAC must allow `ipamclaims` and `ipamclaims/status`
+   (`get`/`list`/`watch`/`update`/`patch`). Current
+   `doc/crds/daemonset-install.yaml` and the Helm chart include these rules.
+3. The IP control-loop (part of the Whereabouts DaemonSet) must be running so
+   claim deletions free pool reservations.
+
+## How it works
+
+1. A controller (for KubeVirt: `ipam-extensions`) creates an `IPAMClaim` owned by
+   the VM and sets `ipam-claim-reference` on the pod's Multus network-selection
+   element.
+2. On CNI **ADD**, Whereabouts:
+   - Resolves the claim (from CNI config / `args.cni`, or from the pod
+     network-selection annotation)
+   - Reuses `status.ips` when present, otherwise allocates and writes
+     `status.ips` + `status.ownerPod`
+   - Tags the IPPool (and overlapping-range) reservation with `ipamclaimref`
+3. On CNI **DEL** / pod GC: claim-backed reservations are **kept**.
+4. When the `IPAMClaim` is deleted, the claim controller releases the IPs.
+
+## Manual example (without KubeVirt)
+
+Create a claim and a Multus-annotated pod that references it:
+
+```yaml
+apiVersion: k8s.cni.cncf.io/v1alpha1
+kind: IPAMClaim
+metadata:
+  name: demo-claim
+  namespace: default
+spec:
+  network: wa-nad
+  interface: net1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-pod
+  namespace: default
+  annotations:
+    k8s.v1.cni.cncf.io/networks: |
+      [{
+        "name": "wa-nad",
+        "interface": "net1",
+        "ipam-claim-reference": "demo-claim"
+      }]
+spec:
+  containers:
+  - name: pause
+    image: registry.k8s.io/pause:3.9
+```
+
+After the pod is Ready:
+
+- `IPAMClaim.status.ips` lists the allocated address(es)
+- The matching `IPPool` allocation includes `ipamclaimref: default/demo-claim`
+
+Delete the pod and recreate another with the same `ipam-claim-reference`: the
+new pod receives the same IP. Delete the `IPAMClaim` to return the address to
+the pool.
+
+## KubeVirt
+
+For VirtualMachines, install
+[`kubevirt/ipam-extensions`](https://github.com/kubevirt/ipam-extensions). It
+creates `IPAMClaim` objects and injects `ipam-claim-reference` into the
+launcher pod's Multus annotation. Whereabouts then provides persistent IPs on
+non-OVN-Kubernetes clusters without KubeVirt API changes.
+
+## Limitations
+
+- Live migration briefly has source and target pods sharing the claim IP;
+  `status.ownerPod` tracks the handoff. Concurrent ADD under heavy churn is the
+  main risk area.
+- Creating/deleting `IPAMClaim` resources is out of scope for Whereabouts; that
+  remains the job of `ipam-extensions` (or your own controller).
+- Persistent IPs for arbitrary non-claim-backed pods are not a goal of this
+  feature (the mechanism is generic if you create claims yourself).

--- a/e2e/client/whereabouts.go
+++ b/e2e/client/whereabouts.go
@@ -14,6 +14,8 @@ import (
 
 	nettypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	netclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
+	ipamclaimsv1alpha1 "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1"
+	ipamclaimsclient "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1/apis/clientset/versioned"
 
 	"github.com/k8snetworkplumbingwg/whereabouts/e2e/entities"
 	whereaboutscnicncfiov1alpha1 "github.com/k8snetworkplumbingwg/whereabouts/pkg/api/whereabouts.cni.cncf.io/v1alpha1"
@@ -30,9 +32,10 @@ const (
 type statefulSetPredicate func(statefulSet *appsv1.StatefulSet, expectedReplicas int) bool
 
 type ClientInfo struct {
-	Client    *kubernetes.Clientset
-	NetClient netclient.K8sCniCncfIoV1Interface
-	WbClient  wbclient.Interface
+	Client           *kubernetes.Clientset
+	NetClient        netclient.K8sCniCncfIoV1Interface
+	WbClient         wbclient.Interface
+	IPAMClaimsClient ipamclaimsclient.Interface
 }
 
 func NewClientInfo(config *rest.Config) (*ClientInfo, error) {
@@ -50,10 +53,16 @@ func NewClientInfo(config *rest.Config) (*ClientInfo, error) {
 		return nil, err
 	}
 
+	claimsClient, err := ipamclaimsclient.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
 	return &ClientInfo{
-		Client:    clientSet,
-		NetClient: netClient,
-		WbClient:  wbClient,
+		Client:           clientSet,
+		NetClient:        netClient,
+		WbClient:         wbClient,
+		IPAMClaimsClient: claimsClient,
 	}, nil
 }
 
@@ -93,7 +102,7 @@ func (c *ClientInfo) ProvisionPod(podName string, namespace string, label, annot
 		return nil, err
 	}
 
-	const podCreateTimeout = 10 * time.Second
+	const podCreateTimeout = 30 * time.Second
 	if err := WaitForPodReady(ctx, c.Client, pod.Namespace, pod.Name, podCreateTimeout); err != nil {
 		return nil, err
 	}
@@ -118,6 +127,33 @@ func (c *ClientInfo) DeletePod(pod *corev1.Pod) error {
 	}
 	return nil
 }
+
+func (c *ClientInfo) CreateIPAMClaim(claim *ipamclaimsv1alpha1.IPAMClaim) (*ipamclaimsv1alpha1.IPAMClaim, error) {
+	return c.IPAMClaimsClient.K8sV1alpha1().IPAMClaims(claim.Namespace).Create(context.TODO(), claim, metav1.CreateOptions{})
+}
+
+func (c *ClientInfo) GetIPAMClaim(namespace, name string) (*ipamclaimsv1alpha1.IPAMClaim, error) {
+	return c.IPAMClaimsClient.K8sV1alpha1().IPAMClaims(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (c *ClientInfo) DeleteIPAMClaim(namespace, name string) error {
+	return c.IPAMClaimsClient.K8sV1alpha1().IPAMClaims(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+}
+
+// IPAMClaimObject builds an empty IPAMClaim for the given network/interface.
+func IPAMClaimObject(name, namespace, network, iface string) *ipamclaimsv1alpha1.IPAMClaim {
+	return &ipamclaimsv1alpha1.IPAMClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: ipamclaimsv1alpha1.IPAMClaimSpec{
+			Network:   network,
+			Interface: iface,
+		},
+	}
+}
+
 
 func (c *ClientInfo) ProvisionReplicaSet(rsName string, namespace string, replicaCount int32, labels, annotations map[string]string) (*appsv1.ReplicaSet, error) {
 	ctx := context.Background()

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -80,8 +80,21 @@ var _ = Describe("Whereabouts functionality", func() {
 			netAttachDef = util.MacvlanNetworkWithWhereaboutsIPAMNetwork(testNetworkName, testNamespace, ipv4TestRange, []string{}, wbstorage.UnnamedNetwork, true)
 
 			By("creating a NetworkAttachmentDefinition for whereabouts")
+			// The cluster is reused between test runs; make this idempotent.
+			_ = clientInfo.DelNetAttachDef(netAttachDef)
 			_, err = clientInfo.AddNetAttachDef(netAttachDef)
 			Expect(err).NotTo(HaveOccurred())
+
+			// Multus reads NADs via informers; give it a moment to pick up the
+			// newly-created definition before we schedule the pod.
+			Eventually(func() bool {
+				_, err := clientInfo.NetClient.NetworkAttachmentDefinitions(testNamespace).Get(
+					context.TODO(),
+					testNetworkName,
+					metav1.GetOptions{},
+				)
+				return err == nil
+			}, 10*time.Second, 500*time.Millisecond).Should(BeTrue())
 		})
 
 		AfterEach(func() {
@@ -889,6 +902,130 @@ var _ = Describe("Whereabouts functionality", func() {
 			})
 		})
 
+		Context("IPAMClaim persistent IPs", func() {
+			const (
+				claimPodName = "whereabouts-ipamclaim-pod"
+				claimName    = "wa-persistent-claim"
+				claimIfName  = "net1"
+			)
+
+			AfterEach(func() {
+				if pod != nil {
+					_ = clientInfo.DeletePod(pod)
+					pod = nil
+				}
+				_ = clientInfo.DeleteIPAMClaim(testNamespace, claimName)
+			})
+
+			It("keeps the same IP across pod delete/recreate and releases on claim delete", func() {
+				By("creating an IPAMClaim")
+				// The cluster can be reused between test runs; make claim create idempotent.
+				_ = clientInfo.DeleteIPAMClaim(testNamespace, claimName)
+				_, err := clientInfo.CreateIPAMClaim(
+					wbtestclient.IPAMClaimObject(claimName, testNamespace, testNetworkName, claimIfName),
+				)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(func() bool {
+					_, err := clientInfo.GetIPAMClaim(testNamespace, claimName)
+					return err == nil
+				}, 10*time.Second, 500*time.Millisecond).Should(BeTrue())
+
+				By("creating a pod referencing the IPAMClaim")
+				// If a prior run crashed, the pod name might still exist.
+				_ = clientInfo.Client.CoreV1().Pods(testNamespace).Delete(
+					context.TODO(),
+					claimPodName,
+					metav1.DeleteOptions{},
+				)
+				pod, err = clientInfo.ProvisionPod(
+					claimPodName,
+					testNamespace,
+					util.PodTierLabel(claimPodName),
+					entities.PodNetworkSelectionElementsWithIPAMClaim(testNetworkName, claimIfName, claimName),
+				)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("recording the allocated IP and verifying claim status")
+				ips, err := retrievers.SecondaryIfaceIPValue(pod, claimIfName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ips).NotTo(BeEmpty())
+				allocatedIP := ips[0]
+				Expect(inRange(ipv4TestRange, allocatedIP)).To(Succeed())
+				fmt.Printf("\nIPAMClaim initial allocation: pod=%s iface=%s ip=%s\n", claimPodName, claimIfName, allocatedIP)
+
+				Eventually(func() []string {
+					c, err := clientInfo.GetIPAMClaim(testNamespace, claimName)
+					Expect(err).NotTo(HaveOccurred())
+					return c.Status.IPs
+				}, 10*time.Second, 500*time.Millisecond).Should(ContainElement(allocatedIP))
+				fmt.Printf("IPAMClaim %s/%s status.ips=%v\n", testNamespace, claimName, []string{allocatedIP})
+
+				claimRef := fmt.Sprintf("%s/%s", testNamespace, claimName)
+				verifyClaimAllocations(clientInfo, ipv4TestRange, allocatedIP, testNamespace, claimPodName, claimIfName, claimRef)
+
+				By("deleting the pod and verifying the allocation is retained")
+				Expect(clientInfo.DeletePod(pod)).To(Succeed())
+				pod = nil
+
+				Consistently(func() bool {
+					ipPool, err := clientInfo.WbClient.WhereaboutsV1alpha1().IPPools(ipPoolNamespace).Get(
+						context.Background(),
+						wbstorage.IPPoolName(wbstorage.PoolIdentifier{IpRange: ipv4TestRange, NetworkName: wbstorage.UnnamedNetwork}),
+						metav1.GetOptions{},
+					)
+					Expect(err).NotTo(HaveOccurred())
+					for _, allocation := range ipPool.Spec.Allocations {
+						if allocation.IPAMClaimRef == claimRef {
+							return true
+						}
+					}
+					return false
+				}, 3*time.Second, 500*time.Millisecond).Should(BeTrue())
+				fmt.Printf("IPAMClaim allocation retained after pod delete: claim=%s ip=%s\n", claimRef, allocatedIP)
+
+				By("recreating the pod with the same claim and verifying the same IP is reused")
+				pod, err = clientInfo.ProvisionPod(
+					claimPodName+"-restart",
+					testNamespace,
+					util.PodTierLabel(claimPodName+"-restart"),
+					entities.PodNetworkSelectionElementsWithIPAMClaim(testNetworkName, claimIfName, claimName),
+				)
+				Expect(err).NotTo(HaveOccurred())
+
+				reusedIPs, err := retrievers.SecondaryIfaceIPValue(pod, claimIfName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(reusedIPs).NotTo(BeEmpty())
+				Expect(reusedIPs[0]).To(Equal(allocatedIP))
+				fmt.Printf("IPAMClaim reused allocation: pod=%s iface=%s ip=%s (same as initial=%s)\n",
+					claimPodName+"-restart", claimIfName, reusedIPs[0], allocatedIP)
+
+				verifyClaimAllocations(clientInfo, ipv4TestRange, allocatedIP, testNamespace, claimPodName+"-restart", claimIfName, claimRef)
+
+				By("deleting the pod then the IPAMClaim and verifying the allocation is released")
+				Expect(clientInfo.DeletePod(pod)).To(Succeed())
+				pod = nil
+				Expect(clientInfo.DeleteIPAMClaim(testNamespace, claimName)).To(Succeed())
+
+				Eventually(func() bool {
+					ipPool, err := clientInfo.WbClient.WhereaboutsV1alpha1().IPPools(ipPoolNamespace).Get(
+						context.Background(),
+						wbstorage.IPPoolName(wbstorage.PoolIdentifier{IpRange: ipv4TestRange, NetworkName: wbstorage.UnnamedNetwork}),
+						metav1.GetOptions{},
+					)
+					if err != nil {
+						return false
+					}
+					for _, allocation := range ipPool.Spec.Allocations {
+						if allocation.IPAMClaimRef == claimRef {
+							return false
+						}
+					}
+					return true
+				}, 15*time.Second, 500*time.Millisecond).Should(BeTrue())
+			})
+		})
+
 	})
 
 	Context("Reconciler conformance", func() {
@@ -971,6 +1108,28 @@ func verifyAllocations(clientInfo *wbtestclient.ClientInfo, ipv4TestRange, ip, t
 
 	Expect(overlapping.Spec.IfName).To(Equal(ifName))
 	Expect(overlapping.Spec.PodRef).To(Equal(getPodRef(testNamespace, podName)))
+}
+
+func verifyClaimAllocations(clientInfo *wbtestclient.ClientInfo, ipv4TestRange, ip, testNamespace, podName, ifName, claimRef string) {
+	ipPool, err := clientInfo.WbClient.WhereaboutsV1alpha1().IPPools(ipPoolNamespace).Get(context.Background(), wbstorage.IPPoolName(wbstorage.PoolIdentifier{IpRange: ipv4TestRange, NetworkName: wbstorage.UnnamedNetwork}), metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	firstIP, _, err := net.ParseCIDR(ipv4TestRange)
+	Expect(err).NotTo(HaveOccurred())
+	offset, err := iphelpers.IPGetOffset(net.ParseIP(ip), firstIP)
+	Expect(err).NotTo(HaveOccurred())
+
+	allocation, ok := ipPool.Spec.Allocations[fmt.Sprintf("%d", offset)]
+	Expect(ok).To(BeTrue())
+	Expect(allocation.PodRef).To(Equal(getPodRef(testNamespace, podName)))
+	Expect(allocation.IfName).To(Equal(ifName))
+	Expect(allocation.IPAMClaimRef).To(Equal(claimRef))
+
+	overlapping, err := clientInfo.WbClient.WhereaboutsV1alpha1().OverlappingRangeIPReservations(ipPoolNamespace).Get(context.Background(), wbstorage.NormalizeIP(net.ParseIP(ip), wbstorage.UnnamedNetwork), metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(overlapping.Spec.IfName).To(Equal(ifName))
+	Expect(overlapping.Spec.PodRef).To(Equal(getPodRef(testNamespace, podName)))
+	Expect(overlapping.Spec.IPAMClaimRef).To(Equal(claimRef))
 }
 
 func allocationForPodRef(podRef string, ipPool v1alpha1.IPPool) []v1alpha1.IPAllocation {

--- a/e2e/entities/helpers.go
+++ b/e2e/entities/helpers.go
@@ -1,6 +1,7 @@
 package entities
 
 import (
+	"encoding/json"
 	"strings"
 
 	nettypes "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
@@ -13,5 +14,22 @@ func ReplicaSetQuery(rsName string) string {
 func PodNetworkSelectionElements(networkNames ...string) map[string]string {
 	return map[string]string{
 		nettypes.NetworkAttachmentAnnot: strings.Join(networkNames, ","),
+	}
+}
+
+// PodNetworkSelectionElementsWithIPAMClaim builds a Multus networks annotation that
+// references a single NAD interface and associates it with an IPAMClaim.
+func PodNetworkSelectionElementsWithIPAMClaim(networkName, ifName, claimName string) map[string]string {
+	elements := []nettypes.NetworkSelectionElement{{
+		Name:               networkName,
+		InterfaceRequest:   ifName,
+		IPAMClaimReference: claimName,
+	}}
+	raw, err := json.Marshal(elements)
+	if err != nil {
+		return PodNetworkSelectionElements(networkName)
+	}
+	return map[string]string{
+		nettypes.NetworkAttachmentAnnot: string(raw),
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,10 @@ require (
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912
 )
 
-require github.com/go-co-op/gocron/v2 v2.19.1
+require (
+	github.com/go-co-op/gocron/v2 v2.19.1
+	github.com/k8snetworkplumbingwg/ipamclaims v0.5.1-alpha
+)
 
 require (
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/k8snetworkplumbingwg/ipamclaims v0.5.1-alpha h1:RPXmPp07hm6l2/a3PSInne+6VnZeSapcFeegpDNklCs=
+github.com/k8snetworkplumbingwg/ipamclaims v0.5.1-alpha/go.mod h1:MGaMX1tJ7MlHDee4/xmqp3guQh+eDiuCLAauqD9K11Q=
 github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7 h1:z4P744DR+PIpkjwXSEc6TvN3L6LVzmUquFgmNm8wSUc=
 github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7/go.mod h1:CM7HAH5PNuIsqjMN0fGc1ydM74Uj+0VZFhob620nklw=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/hack/e2e-setup-kind-cluster.sh
+++ b/hack/e2e-setup-kind-cluster.sh
@@ -98,7 +98,7 @@ trap "rm /tmp/whereabouts-img.tar || true" EXIT
 kind load image-archive --name "$KIND_CLUSTER_NAME" /tmp/whereabouts-img.tar
 
 echo "## install whereabouts"
-for file in "daemonset-install.yaml" "whereabouts.cni.cncf.io_ippools.yaml" "whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml" "whereabouts.cni.cncf.io_nodeslicepools.yaml" "reconciler-deployment.yaml"; do
+for file in "daemonset-install.yaml" "whereabouts.cni.cncf.io_ippools.yaml" "whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml" "whereabouts.cni.cncf.io_nodeslicepools.yaml" "k8s.cni.cncf.io_ipamclaims.yaml" "reconciler-deployment.yaml"; do
   # insert 'imagePullPolicy: Never' under the container 'image' so it is certain that the image used
   # by the daemonset is the one loaded into KinD and not one pulled from a repo
   sed '/        image:/a\        imagePullPolicy: Never' "$ROOT/doc/crds/$file" | retry kubectl apply -f -

--- a/pkg/allocate/allocate.go
+++ b/pkg/allocate/allocate.go
@@ -24,11 +24,20 @@ func (a AssignmentError) Error() string {
 
 // AssignIP assigns an IP using a range and a reserve list.
 func AssignIP(ipamConf types.RangeConfiguration, reservelist []types.IPReservation, containerID, podRef, ifName string) (net.IPNet, []types.IPReservation, error) {
+	return AssignIPForClaim(ipamConf, reservelist, containerID, podRef, ifName, "", nil)
+}
 
-	// Setup the basics here.
-	_, ipnet, _ := net.ParseCIDR(ipamConf.Range)
+// AssignIPForClaim assigns an IP for an optional IPAMClaim.
+// When claimRef is set and preferredIPs is non-empty, those addresses are reused
+// (idempotent take-over for VM stop/start and live migration). Otherwise a new
+// address is chosen and tagged with claimRef when present.
+func AssignIPForClaim(ipamConf types.RangeConfiguration, reservelist []types.IPReservation, containerID, podRef, ifName, claimRef string, preferredIPs []net.IP) (net.IPNet, []types.IPReservation, error) {
+	_, ipnet, err := net.ParseCIDR(ipamConf.Range)
+	if err != nil {
+		return net.IPNet{}, nil, fmt.Errorf("invalid range CIDR %q: %w", ipamConf.Range, err)
+	}
 
-	// Verify if podRef and ifName have already an allocation.
+	// Legacy / same-pod idempotency: podRef + ifName already allocated.
 	for i, r := range reservelist {
 		if r.PodRef == podRef && r.IfName == ifName {
 			logging.Debugf("IP already allocated for podRef: %q - ifName:%q - IP: %s", podRef, ifName, r.IP.String())
@@ -36,8 +45,48 @@ func AssignIP(ipamConf types.RangeConfiguration, reservelist []types.IPReservati
 				logging.Debugf("updating container ID: %q", containerID)
 				reservelist[i].ContainerID = containerID
 			}
-
+			if claimRef != "" && reservelist[i].IPAMClaimRef == "" {
+				reservelist[i].IPAMClaimRef = claimRef
+			}
 			return net.IPNet{IP: r.IP, Mask: ipnet.Mask}, reservelist, nil
+		}
+	}
+
+	if claimRef != "" {
+		// Existing claim-backed reservation (same interface): hand off to new pod.
+		for i, r := range reservelist {
+			if r.IPAMClaimRef == claimRef && r.IfName == ifName {
+				logging.Debugf("Reusing claim-backed IP %s for claim %q (podRef %q -> %q)", r.IP, claimRef, r.PodRef, podRef)
+				reservelist[i].ContainerID = containerID
+				reservelist[i].PodRef = podRef
+				reservelist[i].IfName = ifName
+				return net.IPNet{IP: r.IP, Mask: ipnet.Mask}, reservelist, nil
+			}
+		}
+
+		for _, pref := range preferredIPs {
+			if pref == nil || !ipnet.Contains(pref) {
+				continue
+			}
+			for i, r := range reservelist {
+				if r.IP.Equal(pref) {
+					logging.Debugf("Taking over preferred claim IP %s for claim %q", pref, claimRef)
+					reservelist[i].ContainerID = containerID
+					reservelist[i].PodRef = podRef
+					reservelist[i].IfName = ifName
+					reservelist[i].IPAMClaimRef = claimRef
+					return net.IPNet{IP: r.IP, Mask: ipnet.Mask}, reservelist, nil
+				}
+			}
+			logging.Debugf("Reserving preferred claim IP %s for claim %q", pref, claimRef)
+			reservelist = append(reservelist, types.IPReservation{
+				IP:           pref,
+				ContainerID:  containerID,
+				PodRef:       podRef,
+				IfName:       ifName,
+				IPAMClaimRef: claimRef,
+			})
+			return net.IPNet{IP: pref, Mask: ipnet.Mask}, reservelist, nil
 		}
 	}
 
@@ -45,7 +94,14 @@ func AssignIP(ipamConf types.RangeConfiguration, reservelist []types.IPReservati
 	if err != nil {
 		return net.IPNet{}, nil, err
 	}
-
+	if claimRef != "" {
+		for i := range updatedreservelist {
+			if updatedreservelist[i].IP.Equal(newip) && updatedreservelist[i].PodRef == podRef && updatedreservelist[i].IfName == ifName {
+				updatedreservelist[i].IPAMClaimRef = claimRef
+				break
+			}
+		}
+	}
 	return net.IPNet{IP: newip, Mask: ipnet.Mask}, updatedreservelist, nil
 }
 

--- a/pkg/allocate/claim_test.go
+++ b/pkg/allocate/claim_test.go
@@ -1,0 +1,61 @@
+package allocate
+
+import (
+	"net"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/k8snetworkplumbingwg/whereabouts/pkg/types"
+)
+
+var _ = Describe("AssignIPForClaim", func() {
+	var (
+		ipRange types.RangeConfiguration
+	)
+
+	BeforeEach(func() {
+		ipRange = types.RangeConfiguration{
+			Range:      "192.168.1.0/24",
+			RangeStart: net.ParseIP("192.168.1.1"),
+			RangeEnd:   net.ParseIP("192.168.1.10"),
+		}
+	})
+
+	It("reuses a preferred claim IP for a new pod", func() {
+		existing := []types.IPReservation{{
+			IP:           net.ParseIP("192.168.1.5"),
+			ContainerID:  "old-container",
+			PodRef:       "ns/old-pod",
+			IfName:       "net1",
+			IPAMClaimRef: "ns/vm-net1",
+		}}
+		assigned, updated, err := AssignIPForClaim(
+			ipRange, existing, "new-container", "ns/new-pod", "net1", "ns/vm-net1",
+			[]net.IP{net.ParseIP("192.168.1.5")},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(assigned.IP.String()).To(Equal("192.168.1.5"))
+		Expect(updated).To(HaveLen(1))
+		Expect(updated[0].PodRef).To(Equal("ns/new-pod"))
+		Expect(updated[0].ContainerID).To(Equal("new-container"))
+		Expect(updated[0].IPAMClaimRef).To(Equal("ns/vm-net1"))
+	})
+
+	It("allocates a fresh IP and tags it with the claim ref", func() {
+		assigned, updated, err := AssignIPForClaim(
+			ipRange, nil, "c1", "ns/pod", "net1", "ns/claim-a", nil,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(assigned.IP.String()).To(Equal("192.168.1.1"))
+		Expect(updated).To(HaveLen(1))
+		Expect(updated[0].IPAMClaimRef).To(Equal("ns/claim-a"))
+	})
+
+	It("falls back to legacy AssignIP behavior without a claim", func() {
+		assigned, updated, err := AssignIP(ipRange, nil, "c1", "ns/pod", "net1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(assigned.IP.String()).To(Equal("192.168.1.1"))
+		Expect(updated[0].IPAMClaimRef).To(BeEmpty())
+	})
+})

--- a/pkg/api/whereabouts.cni.cncf.io/v1alpha1/ippool_types.go
+++ b/pkg/api/whereabouts.cni.cncf.io/v1alpha1/ippool_types.go
@@ -25,6 +25,9 @@ type IPAllocation struct {
 	ContainerID string `json:"id"`
 	PodRef      string `json:"podref"`
 	IfName      string `json:"ifname,omitempty"`
+	// IPAMClaimRef is "namespace/name" of the IPAMClaim that owns this allocation.
+	// Empty for legacy pod-scoped allocations.
+	IPAMClaimRef string `json:"ipamclaimref,omitempty"`
 }
 
 // +genclient

--- a/pkg/api/whereabouts.cni.cncf.io/v1alpha1/overlappingrangeipreservation_types.go
+++ b/pkg/api/whereabouts.cni.cncf.io/v1alpha1/overlappingrangeipreservation_types.go
@@ -7,6 +7,8 @@ type OverlappingRangeIPReservationSpec struct {
 	ContainerID string `json:"containerid,omitempty"`
 	PodRef      string `json:"podref"`
 	IfName      string `json:"ifname,omitempty"`
+	// IPAMClaimRef is "namespace/name" of the IPAMClaim that owns this reservation.
+	IPAMClaimRef string `json:"ipamclaimref,omitempty"`
 }
 
 // +genclient

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,6 +14,7 @@ import (
 
 	netutils "k8s.io/utils/net"
 
+	"github.com/k8snetworkplumbingwg/whereabouts/pkg/ipamclaim"
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/logging"
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/types"
 )
@@ -162,7 +163,38 @@ func LoadIPAMConfig(bytes []byte, envArgs string, extraConfigPaths ...string) (*
 	// Copy net name into IPAM so not to drag Net struct around
 	n.IPAM.Name = n.Name
 
+	populateIPAMClaimReference(&n)
+
 	return n.IPAM, n.CNIVersion, nil
+}
+
+// populateIPAMClaimReference fills IPAMClaimReference / Namespace from CNI stdin
+// sources when present. Behavior is inert for allocation until later PRs honor
+// HasIPAMClaim(). Priority (first non-empty wins):
+//  1. IPAM section field ipam-claim-reference
+//  2. Top-level net field ipam-claim-reference
+//  3. args.cni["ipam-claim-reference"] (Multus cni-args injection)
+// Namespace defaults to the pod namespace when a claim reference is set.
+//
+// Note: Multus does not currently inject NSE.IPAMClaimReference into delegate
+// CNI stdin. Production ipam-extensions wiring keeps the claim on the pod's
+// network-selection annotation; follow-up PRs resolve it via the K8s client
+// (see pkg/ipamclaim.ReferenceFromNetworkSelectionElements).
+func populateIPAMClaimReference(n *types.Net) {
+	if n == nil || n.IPAM == nil {
+		return
+	}
+
+	if n.IPAM.IPAMClaimReference == "" && n.IPAMClaimReference != "" {
+		n.IPAM.IPAMClaimReference = n.IPAMClaimReference
+	}
+	if n.IPAM.IPAMClaimReference == "" && n.Args != nil {
+		n.IPAM.IPAMClaimReference = ipamclaim.ReferenceFromCNIArgs(n.Args.CNI)
+	}
+
+	if n.IPAM.IPAMClaimReference != "" && n.IPAM.IPAMClaimNamespace == "" {
+		n.IPAM.IPAMClaimNamespace = n.IPAM.PodNamespace
+	}
 }
 
 func pathExists(path string) bool {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -412,6 +412,131 @@ var _ = Describe("Allocation operations", func() {
 				HavePrefix(
 					"LoadIPAMConfig - JSON Parsing Error: invalid character 'a' looking for beginning of object key string")))
 	})
+
+	It("parses ipam-claim-reference from the IPAM section", func() {
+		confPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(`{
+			"kubernetes": {"kubeconfig": "/etc/cni/net.d/whereabouts.d/whereabouts.kubeconfig"}
+		}`), 0755)).To(Succeed())
+
+		conf := `{
+			"cniVersion": "0.3.1",
+			"name": "mynet",
+			"type": "ipvlan",
+			"ipam": {
+				"type": "whereabouts",
+				"range": "192.168.1.0/24",
+				"configuration_path": "` + confPath + `",
+				"ipam-claim-reference": "vm-iface0",
+				"ipam-claim-namespace": "vms"
+			}
+		}`
+		envArgs := "K8S_POD_NAME=virt-launcher-vm;K8S_POD_NAMESPACE=vms"
+		ipamConfig, _, err := LoadIPAMConfig([]byte(conf), envArgs)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ipamConfig.IPAMClaimReference).To(Equal("vm-iface0"))
+		Expect(ipamConfig.IPAMClaimNamespace).To(Equal("vms"))
+		Expect(ipamConfig.HasIPAMClaim()).To(BeTrue())
+		Expect(ipamConfig.GetIPAMClaimRef()).To(Equal("vms/vm-iface0"))
+	})
+
+	It("defaults claim namespace to the pod namespace", func() {
+		confPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(`{
+			"kubernetes": {"kubeconfig": "/etc/cni/net.d/whereabouts.d/whereabouts.kubeconfig"}
+		}`), 0755)).To(Succeed())
+
+		conf := `{
+			"cniVersion": "0.3.1",
+			"name": "mynet",
+			"type": "ipvlan",
+			"ipam": {
+				"type": "whereabouts",
+				"range": "192.168.1.0/24",
+				"configuration_path": "` + confPath + `",
+				"ipam-claim-reference": "vm-iface0"
+			}
+		}`
+		envArgs := "K8S_POD_NAME=virt-launcher-vm;K8S_POD_NAMESPACE=tenant-a"
+		ipamConfig, _, err := LoadIPAMConfig([]byte(conf), envArgs)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ipamConfig.IPAMClaimReference).To(Equal("vm-iface0"))
+		Expect(ipamConfig.IPAMClaimNamespace).To(Equal("tenant-a"))
+		Expect(ipamConfig.GetIPAMClaimRef()).To(Equal("tenant-a/vm-iface0"))
+	})
+
+	It("reads ipam-claim-reference from top-level net config", func() {
+		confPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(`{
+			"kubernetes": {"kubeconfig": "/etc/cni/net.d/whereabouts.d/whereabouts.kubeconfig"}
+		}`), 0755)).To(Succeed())
+
+		conf := `{
+			"cniVersion": "0.3.1",
+			"name": "mynet",
+			"type": "ipvlan",
+			"ipam-claim-reference": "top-level-claim",
+			"ipam": {
+				"type": "whereabouts",
+				"range": "192.168.1.0/24",
+				"configuration_path": "` + confPath + `"
+			}
+		}`
+		envArgs := "K8S_POD_NAME=pod;K8S_POD_NAMESPACE=ns"
+		ipamConfig, _, err := LoadIPAMConfig([]byte(conf), envArgs)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ipamConfig.IPAMClaimReference).To(Equal("top-level-claim"))
+		Expect(ipamConfig.IPAMClaimNamespace).To(Equal("ns"))
+	})
+
+	It("reads ipam-claim-reference from args.cni", func() {
+		confPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(`{
+			"kubernetes": {"kubeconfig": "/etc/cni/net.d/whereabouts.d/whereabouts.kubeconfig"}
+		}`), 0755)).To(Succeed())
+
+		conf := `{
+			"cniVersion": "0.3.1",
+			"name": "mynet",
+			"type": "ipvlan",
+			"args": {
+				"cni": {
+					"ipam-claim-reference": "from-cni-args"
+				}
+			},
+			"ipam": {
+				"type": "whereabouts",
+				"range": "192.168.1.0/24",
+				"configuration_path": "` + confPath + `"
+			}
+		}`
+		envArgs := "K8S_POD_NAME=pod;K8S_POD_NAMESPACE=ns"
+		ipamConfig, _, err := LoadIPAMConfig([]byte(conf), envArgs)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ipamConfig.IPAMClaimReference).To(Equal("from-cni-args"))
+	})
+
+	It("leaves claim fields empty when unset (legacy behavior)", func() {
+		confPath := filepath.Join(tmpDir, "whereabouts.conf")
+		Expect(os.WriteFile(confPath, []byte(`{
+			"kubernetes": {"kubeconfig": "/etc/cni/net.d/whereabouts.d/whereabouts.kubeconfig"}
+		}`), 0755)).To(Succeed())
+
+		conf := `{
+			"cniVersion": "0.3.1",
+			"name": "mynet",
+			"type": "ipvlan",
+			"ipam": {
+				"type": "whereabouts",
+				"range": "192.168.1.0/24",
+				"configuration_path": "` + confPath + `"
+			}
+		}`
+		ipamConfig, _, err := LoadIPAMConfig([]byte(conf), "K8S_POD_NAME=pod;K8S_POD_NAMESPACE=ns")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ipamConfig.HasIPAMClaim()).To(BeFalse())
+		Expect(ipamConfig.GetIPAMClaimRef()).To(BeEmpty())
+	})
 })
 
 func generateIPAMConfWithOverlappingRanges() string {

--- a/pkg/controlloop/claim.go
+++ b/pkg/controlloop/claim.go
@@ -1,0 +1,159 @@
+package controlloop
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	ipamclaimsv1alpha1 "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1"
+	ipamclaimsclient "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1/apis/clientset/versioned"
+	ipamclaimsinformers "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1/apis/informers/externalversions"
+
+	wbclientset "github.com/k8snetworkplumbingwg/whereabouts/pkg/generated/clientset/versioned"
+	wbinformers "github.com/k8snetworkplumbingwg/whereabouts/pkg/generated/informers/externalversions"
+	"github.com/k8snetworkplumbingwg/whereabouts/pkg/logging"
+	wbclient "github.com/k8snetworkplumbingwg/whereabouts/pkg/storage/kubernetes"
+	"github.com/k8snetworkplumbingwg/whereabouts/pkg/types"
+)
+
+// ClaimController releases Whereabouts allocations when an IPAMClaim is deleted.
+type ClaimController struct {
+	wbClient          wbclientset.Interface
+	claimsClient      ipamclaimsclient.Interface
+	areClaimsSynched  cache.InformerSynced
+	areIPPoolsSynched cache.InformerSynced
+	workqueue         workqueue.TypedRateLimitingInterface[string]
+}
+
+// NewClaimController builds a controller that watches IPAMClaim deletions.
+func NewClaimController(
+	wbClient wbclientset.Interface,
+	claimsClient ipamclaimsclient.Interface,
+	wbSharedInformerFactory wbinformers.SharedInformerFactory,
+	claimsInformerFactory ipamclaimsinformers.SharedInformerFactory,
+) *ClaimController {
+	ipPoolInformer := wbSharedInformerFactory.Whereabouts().V1alpha1().IPPools().Informer()
+	claimsSharedInformer := claimsInformerFactory.K8s().V1alpha1().IPAMClaims().Informer()
+
+	queue := workqueue.NewTypedRateLimitingQueue[string](
+		workqueue.DefaultTypedControllerRateLimiter[string]())
+
+	claimsSharedInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		DeleteFunc: func(obj interface{}) {
+			onClaimDelete(queue, obj)
+		},
+	})
+
+	return &ClaimController{
+		wbClient:          wbClient,
+		claimsClient:      claimsClient,
+		areClaimsSynched:  claimsSharedInformer.HasSynced,
+		areIPPoolsSynched: ipPoolInformer.HasSynced,
+		workqueue:         queue,
+	}
+}
+
+// Start runs the claim controller worker after cache sync.
+func (cc *ClaimController) Start(stopChan <-chan struct{}) {
+	logging.Verbosef("starting IPAMClaim controller")
+	if ok := cache.WaitForCacheSync(stopChan, cc.areClaimsSynched, cc.areIPPoolsSynched); !ok {
+		logging.Verbosef("failed waiting for IPAMClaim caches to sync")
+	}
+	go wait.Until(cc.worker, syncPeriod, stopChan)
+}
+
+// Shutdown stops the claim workqueue.
+func (cc *ClaimController) Shutdown() {
+	cc.workqueue.ShutDown()
+}
+
+func (cc *ClaimController) worker() {
+	for cc.processNextWorkItem() {
+	}
+}
+
+func (cc *ClaimController) processNextWorkItem() bool {
+	claimRef, shouldQuit := cc.workqueue.Get()
+	if shouldQuit {
+		return false
+	}
+	defer cc.workqueue.Done(claimRef)
+
+	err := cc.releaseClaimAllocations(context.TODO(), claimRef)
+	if err != nil {
+		logging.Errorf("failed releasing allocations for claim %s: %v", claimRef, err)
+		if cc.workqueue.NumRequeues(claimRef) <= maxRetries {
+			cc.workqueue.AddRateLimited(claimRef)
+			return true
+		}
+	}
+	cc.workqueue.Forget(claimRef)
+	return true
+}
+
+func (cc *ClaimController) releaseClaimAllocations(ctx context.Context, claimRef string) error {
+	logging.Verbosef("releasing Whereabouts allocations for deleted IPAMClaim %s", claimRef)
+
+	client := wbclient.NewKubernetesClient(cc.wbClient, nil, cc.claimsClient)
+	pools, err := client.ListIPPools()
+	if err != nil {
+		return fmt.Errorf("listing IP pools: %w", err)
+	}
+
+	for _, pool := range pools {
+		reservations := pool.Allocations()
+		changed := false
+		updated := make([]types.IPReservation, 0, len(reservations))
+		for _, r := range reservations {
+			if r.IPAMClaimRef == claimRef {
+				logging.Verbosef("removing claim-backed reservation %s for claim %s", r.IP, claimRef)
+				changed = true
+				continue
+			}
+			updated = append(updated, r)
+		}
+		if !changed {
+			continue
+		}
+		if err := pool.Update(ctx, updated); err != nil {
+			return fmt.Errorf("updating pool after claim %s delete: %w", claimRef, err)
+		}
+	}
+
+	overlapping, err := client.ListOverlappingIPs()
+	if err != nil {
+		return fmt.Errorf("listing overlapping IPs: %w", err)
+	}
+	for i := range overlapping {
+		o := &overlapping[i]
+		if o.Spec.IPAMClaimRef == claimRef {
+			logging.Verbosef("removing overlapping reservation %s for claim %s", o.Name, claimRef)
+			if err := client.DeleteOverlappingIP(o); err != nil {
+				return fmt.Errorf("deleting overlapping IP %s: %w", o.Name, err)
+			}
+		}
+	}
+	return nil
+}
+
+func onClaimDelete(queue workqueue.TypedRateLimitingInterface[string], obj interface{}) {
+	claim, ok := obj.(*ipamclaimsv1alpha1.IPAMClaim)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			logging.Errorf("error decoding IPAMClaim delete event: unexpected type %T", obj)
+			return
+		}
+		claim, ok = tombstone.Obj.(*ipamclaimsv1alpha1.IPAMClaim)
+		if !ok {
+			logging.Errorf("error decoding IPAMClaim tombstone: unexpected type %T", tombstone.Obj)
+			return
+		}
+	}
+	claimRef := fmt.Sprintf("%s/%s", claim.Namespace, claim.Name)
+	logging.Verbosef("IPAMClaim deleted: %s", claimRef)
+	queue.Add(claimRef)
+}

--- a/pkg/controlloop/pod.go
+++ b/pkg/controlloop/pod.go
@@ -225,6 +225,11 @@ func (pc *PodController) garbageCollectPodIPs(pod *v1.Pod) error {
 				if allocation.PodRef == podID(podNamespace, podName) {
 					logging.Verbosef("Found an existing allocation: %+v", allocation)
 
+					if allocation.IPAMClaimRef != "" {
+						logging.Verbosef("Skipping GC for claim-backed allocation %q (released when IPAMClaim is deleted)", allocation.IPAMClaimRef)
+						continue
+					}
+
 					// The allocation could belong to a new pod with the same name and namespace. Stateful set scenarios.
 					// The previous pod should be gone by the time a pod deletion event is received.
 					if newPod, err := pc.k8sClient.CoreV1().Pods(podNamespace).Get(context.TODO(), podName, metav1.GetOptions{}); err == nil {
@@ -240,7 +245,7 @@ func (pc *PodController) garbageCollectPodIPs(pod *v1.Pod) error {
 
 					logging.Verbosef("stale allocation to cleanup: %+v", allocation)
 
-					client := *wbclient.NewKubernetesClient(pc.wbClient, pc.k8sClient)
+					client := *wbclient.NewKubernetesClient(pc.wbClient, pc.k8sClient, nil)
 					k8sIPAM := &wbclient.KubernetesIPAM{
 						Config:      *ipamConfig,
 						ContainerID: allocation.ContainerID,

--- a/pkg/ipamclaim/claim.go
+++ b/pkg/ipamclaim/claim.go
@@ -1,0 +1,180 @@
+package ipamclaim
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	ipamclaimsv1alpha1 "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1"
+	ipamclaimsclient "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1/apis/clientset/versioned"
+	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	nadutils "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils"
+	"gomodules.xyz/jsonpatch/v2"
+
+	"github.com/k8snetworkplumbingwg/whereabouts/pkg/logging"
+	wbtypes "github.com/k8snetworkplumbingwg/whereabouts/pkg/types"
+)
+
+// ResolveFromPodAnnotation looks up the pod and reads IPAMClaimReference from its
+// network-selection elements when the config does not already carry a claim ref.
+// This matches ipam-extensions / OVN-Kubernetes wiring.
+func ResolveFromPodAnnotation(ctx context.Context, clientset kubernetes.Interface, ipamConf *wbtypes.IPAMConfig, ifName string) error {
+	if ipamConf == nil || ipamConf.HasIPAMClaim() || clientset == nil {
+		return nil
+	}
+	if ipamConf.PodName == "" || ipamConf.PodNamespace == "" {
+		return nil
+	}
+
+	// During early pod sandbox creation, the Pod may not be readable from the API yet.
+	// Retry NotFound for a bounded amount of time so we can resolve the IPAMClaim reference.
+	// (The CNI ADD path can succeed even if claim resolution fails; that would leave
+	// claim-backed allocations untagged.)
+	var pod *corev1.Pod
+	// Keep this reasonably high for "brand new pod" timing in kind clusters.
+	deadline := time.Now().Add(45 * time.Second)
+	for {
+		// Don't couple the retry loop to the request context deadline. A short per-attempt
+		// timeout keeps each API call bounded.
+		attemptCtx, attemptCancel := context.WithTimeout(context.Background(), 1*time.Second)
+		p, err := clientset.CoreV1().Pods(ipamConf.PodNamespace).Get(attemptCtx, ipamConf.PodName, metav1.GetOptions{})
+		attemptCancel()
+		if err == nil {
+			pod = p
+			break
+		}
+		if apierrors.IsNotFound(err) {
+			logging.Debugf("Pod %s/%s not found while resolving IPAMClaim; retrying", ipamConf.PodNamespace, ipamConf.PodName)
+			if time.Now().After(deadline) {
+				logging.Debugf("Giving up resolving IPAMClaim: pod %s/%s not found after retries", ipamConf.PodNamespace, ipamConf.PodName)
+				return nil
+			}
+			time.Sleep(200 * time.Millisecond)
+			continue
+		}
+		return fmt.Errorf("failed to get pod %s/%s for IPAMClaim resolution: %w", ipamConf.PodNamespace, ipamConf.PodName, err)
+	}
+
+	claimName, err := ClaimNameFromPod(pod, ipamConf.Name, ifName)
+	if err != nil {
+		return err
+	}
+	if claimName == "" {
+		logging.Debugf("No IPAMClaimReference found in pod %s/%s for network=%q ifName=%q", pod.Namespace, pod.Name, ipamConf.Name, ifName)
+		return nil
+	}
+
+	ipamConf.IPAMClaimReference = claimName
+	if ipamConf.IPAMClaimNamespace == "" {
+		ipamConf.IPAMClaimNamespace = ipamConf.PodNamespace
+	}
+	logging.Debugf("Resolved IPAMClaim reference %q from pod network-selection annotation", ipamConf.GetIPAMClaimRef())
+	return nil
+}
+
+// ClaimNameFromPod extracts the IPAMClaim name for the given network/interface.
+func ClaimNameFromPod(pod *corev1.Pod, networkName, ifName string) (string, error) {
+	if pod == nil {
+		return "", nil
+	}
+	elements, err := nadutils.ParsePodNetworkAnnotation(pod)
+	if err != nil {
+		var noNet *nadv1.NoK8sNetworkError
+		if errors.As(err, &noNet) {
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to parse pod network annotation: %w", err)
+	}
+	logging.Debugf("Parsed %d NSE elements for pod %s/%s (network=%q ifName=%q)", len(elements), pod.Namespace, pod.Name, networkName, ifName)
+	for _, el := range elements {
+		if el == nil {
+			continue
+		}
+		logging.Debugf("NSE element name=%q ifaceReq=%q claimRef=%q", el.Name, el.InterfaceRequest, el.IPAMClaimReference)
+	}
+	return ReferenceFromNetworkSelectionElements(elements, networkName, ifName), nil
+}
+
+// ParseClaimIPs converts IPAMClaim status.ips into net.IP values.
+func ParseClaimIPs(claim *ipamclaimsv1alpha1.IPAMClaim) []net.IP {
+	if claim == nil {
+		return nil
+	}
+	var ips []net.IP
+	for _, s := range claim.Status.IPs {
+		if ip := net.ParseIP(s); ip != nil {
+			ips = append(ips, ip)
+		}
+	}
+	return ips
+}
+
+// GetClaim fetches an IPAMClaim by namespace/name from IPAMConfig.
+func GetClaim(ctx context.Context, client ipamclaimsclient.Interface, ipamConf wbtypes.IPAMConfig) (*ipamclaimsv1alpha1.IPAMClaim, error) {
+	if !ipamConf.HasIPAMClaim() || client == nil {
+		return nil, nil
+	}
+	ns := ipamConf.IPAMClaimNamespace
+	if ns == "" {
+		ns = ipamConf.PodNamespace
+	}
+	return client.K8sV1alpha1().IPAMClaims(ns).Get(ctx, ipamConf.IPAMClaimReference, metav1.GetOptions{})
+}
+
+// PersistClaimIPs writes allocated addresses and ownerPod onto the IPAMClaim status.
+func PersistClaimIPs(ctx context.Context, client ipamclaimsclient.Interface, ipamConf wbtypes.IPAMConfig, allocated []net.IPNet) error {
+	if !ipamConf.HasIPAMClaim() || client == nil || len(allocated) == 0 {
+		return nil
+	}
+
+	ns := ipamConf.IPAMClaimNamespace
+	if ns == "" {
+		ns = ipamConf.PodNamespace
+	}
+
+	claim, err := client.K8sV1alpha1().IPAMClaims(ns).Get(ctx, ipamConf.IPAMClaimReference, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get IPAMClaim %s/%s: %w", ns, ipamConf.IPAMClaimReference, err)
+	}
+
+	ipStrs := make([]string, 0, len(allocated))
+	for _, ipn := range allocated {
+		ipStrs = append(ipStrs, ipn.IP.String())
+	}
+
+	if len(claim.Status.IPs) == 0 {
+		claim.Status.IPs = ipStrs
+	}
+	claim.Status.OwnerPod = &ipamclaimsv1alpha1.OwnerPod{Name: ipamConf.PodName}
+
+	updated, err := client.K8sV1alpha1().IPAMClaims(ns).UpdateStatus(ctx, claim, metav1.UpdateOptions{})
+	if err != nil {
+		logging.Debugf("UpdateStatus failed (%v); attempting status patch", err)
+		return patchClaimStatus(ctx, client, ns, claim.Name, claim.ResourceVersion, claim.Status.IPs, ipamConf.PodName)
+	}
+	logging.Debugf("Persisted IPs %v on IPAMClaim %s/%s (resourceVersion %s)", updated.Status.IPs, ns, claim.Name, updated.ResourceVersion)
+	return nil
+}
+
+func patchClaimStatus(ctx context.Context, client ipamclaimsclient.Interface, ns, name, resourceVersion string, ips []string, ownerPod string) error {
+	ops := []jsonpatch.Operation{
+		{Operation: "test", Path: "/metadata/resourceVersion", Value: resourceVersion},
+		{Operation: "replace", Path: "/status/ips", Value: ips},
+		{Operation: "add", Path: "/status/ownerPod", Value: map[string]string{"name": ownerPod}},
+	}
+	patchData, err := json.Marshal(ops)
+	if err != nil {
+		return err
+	}
+	_, err = client.K8sV1alpha1().IPAMClaims(ns).Patch(ctx, name, types.JSONPatchType, patchData, metav1.PatchOptions{}, "status")
+	return err
+}

--- a/pkg/ipamclaim/reference.go
+++ b/pkg/ipamclaim/reference.go
@@ -1,0 +1,76 @@
+// Package ipamclaim helpers for the IPAMClaim persistent-IP contract
+// (k8snetworkplumbingwg/ipamclaims), used with Multus network-selection elements
+// and kubevirt/ipam-extensions.
+package ipamclaim
+
+import (
+	ipamclaimsv1alpha1 "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1"
+	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+)
+
+// ReferenceField is the NetworkSelectionElement / CNI JSON field name for the claim.
+const ReferenceField = "ipam-claim-reference"
+
+// GroupVersion is the IPAMClaim API group/version used by this plugin.
+var GroupVersion = ipamclaimsv1alpha1.SchemeGroupVersion
+
+// ReferenceFromNetworkSelectionElements returns the IPAMClaim name from the
+// network-selection element matching ifName and/or networkName.
+// This mirrors how OVN-Kubernetes / ipam-extensions wire persistent IPs: the
+// claim reference lives on the pod annotation NSE, not (today) in Multus-injected
+// CNI stdin for delegate IPAM plugins.
+func ReferenceFromNetworkSelectionElements(elements []*nadv1.NetworkSelectionElement, networkName, ifName string) string {
+	if len(elements) == 0 {
+		return ""
+	}
+
+	for _, el := range elements {
+		if el == nil || el.IPAMClaimReference == "" {
+			continue
+		}
+		if ifName != "" && el.InterfaceRequest != "" && el.InterfaceRequest == ifName {
+			return el.IPAMClaimReference
+		}
+	}
+
+	for _, el := range elements {
+		if el == nil || el.IPAMClaimReference == "" {
+			continue
+		}
+		if networkName != "" && el.Name == networkName {
+			return el.IPAMClaimReference
+		}
+	}
+
+	// Single-element annotation with a claim: use it when ifName/network filters
+	// did not uniquely match (common for a single secondary attachment).
+	var match string
+	count := 0
+	for _, el := range elements {
+		if el == nil || el.IPAMClaimReference == "" {
+			continue
+		}
+		match = el.IPAMClaimReference
+		count++
+	}
+	if count == 1 {
+		return match
+	}
+	return ""
+}
+
+// ReferenceFromCNIArgs extracts ipam-claim-reference from Multus-injected args.cni.
+func ReferenceFromCNIArgs(cniArgs *map[string]interface{}) string {
+	if cniArgs == nil {
+		return ""
+	}
+	raw, ok := (*cniArgs)[ReferenceField]
+	if !ok {
+		return ""
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return ""
+	}
+	return s
+}

--- a/pkg/ipamclaim/reference_test.go
+++ b/pkg/ipamclaim/reference_test.go
@@ -1,0 +1,92 @@
+package ipamclaim
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	nadv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
+	"github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils"
+)
+
+func TestIPAMClaim(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ipamclaim")
+}
+
+var _ = Describe("IPAMClaim reference helpers", func() {
+	Describe("ReferenceFromNetworkSelectionElements", func() {
+		It("returns empty for nil/empty elements", func() {
+			Expect(ReferenceFromNetworkSelectionElements(nil, "net", "net1")).To(BeEmpty())
+			Expect(ReferenceFromNetworkSelectionElements([]*nadv1.NetworkSelectionElement{}, "net", "net1")).To(BeEmpty())
+		})
+
+		It("matches by interface name", func() {
+			elements := []*nadv1.NetworkSelectionElement{
+				{Name: "other", InterfaceRequest: "net2", IPAMClaimReference: "claim-b"},
+				{Name: "mynet", InterfaceRequest: "net1", IPAMClaimReference: "claim-a"},
+			}
+			Expect(ReferenceFromNetworkSelectionElements(elements, "mynet", "net1")).To(Equal("claim-a"))
+		})
+
+		It("matches by network name when interface is unset on the element", func() {
+			elements := []*nadv1.NetworkSelectionElement{
+				{Name: "mynet", IPAMClaimReference: "claim-a"},
+			}
+			Expect(ReferenceFromNetworkSelectionElements(elements, "mynet", "net1")).To(Equal("claim-a"))
+		})
+
+		It("falls back to the sole claim-bearing element", func() {
+			elements := []*nadv1.NetworkSelectionElement{
+				{Name: "mynet", IPAMClaimReference: "only-claim"},
+				{Name: "other"},
+			}
+			Expect(ReferenceFromNetworkSelectionElements(elements, "unused", "unused")).To(Equal("only-claim"))
+		})
+
+		It("returns empty when multiple claims exist and filters do not match", func() {
+			elements := []*nadv1.NetworkSelectionElement{
+				{Name: "a", IPAMClaimReference: "claim-a"},
+				{Name: "b", IPAMClaimReference: "claim-b"},
+			}
+			Expect(ReferenceFromNetworkSelectionElements(elements, "c", "net9")).To(BeEmpty())
+		})
+	})
+
+	Describe("ReferenceFromCNIArgs", func() {
+		It("reads ipam-claim-reference from cni args", func() {
+			args := map[string]interface{}{ReferenceField: "vm-eth0"}
+			Expect(ReferenceFromCNIArgs(&args)).To(Equal("vm-eth0"))
+		})
+
+		It("returns empty for missing or non-string values", func() {
+			Expect(ReferenceFromCNIArgs(nil)).To(BeEmpty())
+			args := map[string]interface{}{ReferenceField: 42}
+			Expect(ReferenceFromCNIArgs(&args)).To(BeEmpty())
+		})
+	})
+
+	Describe("ParsePodNetworkAnnotation integration", func() {
+		It("extracts IPAMClaimReference for matching interface", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						nadv1.NetworkAttachmentAnnot: `[{"name":"wa-nad","interface":"net1","ipam-claim-reference":"wa-persistent-claim"}]`,
+					},
+				},
+			}
+
+			elements, err := utils.ParsePodNetworkAnnotation(pod)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(elements).To(HaveLen(1))
+			Expect(elements[0].InterfaceRequest).To(Equal("net1"))
+			Expect(elements[0].IPAMClaimReference).To(Equal("wa-persistent-claim"))
+
+			Expect(ReferenceFromNetworkSelectionElements(elements, "", "net1")).To(Equal("wa-persistent-claim"))
+		})
+	})
+})

--- a/pkg/reconciler/ip_test.go
+++ b/pkg/reconciler/ip_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Whereabouts IP reconciler", func() {
 				Context("reconciling the IPPool", func() {
 					BeforeEach(func() {
 						var err error
-						reconcileLooper, err = NewReconcileLooperWithClient(kubernetes.NewKubernetesClient(wbClient, k8sClientSet))
+						reconcileLooper, err = NewReconcileLooperWithClient(kubernetes.NewKubernetesClient(wbClient, k8sClientSet, nil))
 						Expect(err).NotTo(HaveOccurred())
 					})
 
@@ -138,7 +138,7 @@ var _ = Describe("Whereabouts IP reconciler", func() {
 			Context("reconciling the IPPool", func() {
 				BeforeEach(func() {
 					var err error
-					reconcileLooper, err = NewReconcileLooperWithClient(kubernetes.NewKubernetesClient(wbClient, k8sClientSet))
+					reconcileLooper, err = NewReconcileLooperWithClient(kubernetes.NewKubernetesClient(wbClient, k8sClientSet, nil))
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -189,7 +189,7 @@ var _ = Describe("Whereabouts IP reconciler", func() {
 
 			By("initializing the reconciler")
 			var err error
-			reconcileLooper, err = NewReconcileLooperWithClient(kubernetes.NewKubernetesClient(wbClient, k8sClientSet))
+			reconcileLooper, err = NewReconcileLooperWithClient(kubernetes.NewKubernetesClient(wbClient, k8sClientSet, nil))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("reconciling and checking that the correct entry is deleted")
@@ -271,7 +271,7 @@ var _ = Describe("Whereabouts IP reconciler", func() {
 
 		It("will delete an orphaned IP address", func() {
 			Expect(k8sClientSet.CoreV1().Pods(namespace).Delete(context.TODO(), pods[podIndexToRemove].Name, metav1.DeleteOptions{})).NotTo(HaveOccurred())
-			newReconciler, err := NewReconcileLooperWithClient(kubernetes.NewKubernetesClient(wbClient, k8sClientSet))
+			newReconciler, err := NewReconcileLooperWithClient(kubernetes.NewKubernetesClient(wbClient, k8sClientSet, nil))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(newReconciler.ReconcileOverlappingIPAddresses()).To(Succeed())
 
@@ -337,7 +337,7 @@ var _ = Describe("Whereabouts IP reconciler", func() {
 		})
 
 		It("will not delete an IP address that isn't orphaned after running reconciler", func() {
-			newReconciler, err := NewReconcileLooperWithClient(kubernetes.NewKubernetesClient(wbClient, k8sClientSet))
+			newReconciler, err := NewReconcileLooperWithClient(kubernetes.NewKubernetesClient(wbClient, k8sClientSet, nil))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(newReconciler.ReconcileOverlappingIPAddresses()).To(Succeed())
 
@@ -368,7 +368,7 @@ var _ = Describe("Whereabouts IP reconciler", func() {
 
 			pool = generateIPPoolSpec(ipRange, namespace, poolName, pod.Name)
 			wbClient = fakewbclient.NewSimpleClientset(pool)
-			reconcileLooper, err = NewReconcileLooperWithClient(kubernetes.NewKubernetesClient(wbClient, k8sClientSet))
+			reconcileLooper, err = NewReconcileLooperWithClient(kubernetes.NewKubernetesClient(wbClient, k8sClientSet, nil))
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/pkg/reconciler/iploop.go
+++ b/pkg/reconciler/iploop.go
@@ -75,6 +75,10 @@ func (rl *ReconcileLooper) findOrphanedIPsPerPool(ipPools []storage.IPPool) erro
 				_ = logging.Errorf("pod ref missing for Allocations: %s", ipReservation)
 				continue
 			}
+			if ipReservation.IPAMClaimRef != "" {
+				logging.Debugf("skipping claim-backed reservation %s (%s)", ipReservation.IP, ipReservation.IPAMClaimRef)
+				continue
+			}
 			if !rl.isOrphanedIP(ipReservation.PodRef, ipReservation.IP.String()) {
 				logging.Debugf("pod ref %s is not listed in the live pods list", ipReservation.PodRef)
 				orphanIP.Allocations = append(orphanIP.Allocations, ipReservation)
@@ -224,6 +228,11 @@ func (rl *ReconcileLooper) findClusterWideIPReservations() error {
 		denormalizedip := strings.ReplaceAll(ip, "-", ":")
 
 		podRef := clusterWideIPReservation.Spec.PodRef
+
+		if clusterWideIPReservation.Spec.IPAMClaimRef != "" {
+			logging.Debugf("skipping claim-backed overlapping reservation %s (%s)", denormalizedip, clusterWideIPReservation.Spec.IPAMClaimRef)
+			continue
+		}
 
 		if !rl.isOrphanedIP(podRef, denormalizedip) {
 			logging.Debugf("pod ref %s is not listed in the live pods list", podRef)

--- a/pkg/storage/kubernetes/client.go
+++ b/pkg/storage/kubernetes/client.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
+	ipamclaimsclient "github.com/k8snetworkplumbingwg/ipamclaims/pkg/crd/ipamclaims/v1alpha1/apis/clientset/versioned"
 	whereaboutsv1alpha1 "github.com/k8snetworkplumbingwg/whereabouts/pkg/api/whereabouts.cni.cncf.io/v1alpha1"
 	wbclient "github.com/k8snetworkplumbingwg/whereabouts/pkg/generated/clientset/versioned"
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/logging"
@@ -20,9 +21,10 @@ const listRequestTimeout = 30 * time.Second
 
 // Client has info on how to connect to the kubernetes cluster
 type Client struct {
-	client    wbclient.Interface
-	clientSet kubernetes.Interface
-	retries   int
+	client           wbclient.Interface
+	clientSet        kubernetes.Interface
+	ipamClaimsClient ipamclaimsclient.Interface
+	retries          int
 }
 
 func NewClient() (*Client, error) {
@@ -57,14 +59,20 @@ func newClient(config *rest.Config) (*Client, error) {
 		return nil, err
 	}
 
-	return NewKubernetesClient(c, clientSet), nil
+	claimsClient, err := ipamclaimsclient.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewKubernetesClient(c, clientSet, claimsClient), nil
 }
 
-func NewKubernetesClient(k8sClient wbclient.Interface, k8sClientSet kubernetes.Interface) *Client {
+func NewKubernetesClient(k8sClient wbclient.Interface, k8sClientSet kubernetes.Interface, claimsClient ipamclaimsclient.Interface) *Client {
 	return &Client{
-		client:    k8sClient,
-		clientSet: k8sClientSet,
-		retries:   storage.DatastoreRetries,
+		client:           k8sClient,
+		clientSet:        k8sClientSet,
+		ipamClaimsClient: claimsClient,
+		retries:          storage.DatastoreRetries,
 	}
 }
 

--- a/pkg/storage/kubernetes/ipam.go
+++ b/pkg/storage/kubernetes/ipam.go
@@ -23,6 +23,7 @@ import (
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/allocate"
 	whereaboutsv1alpha1 "github.com/k8snetworkplumbingwg/whereabouts/pkg/api/whereabouts.cni.cncf.io/v1alpha1"
 	wbclient "github.com/k8snetworkplumbingwg/whereabouts/pkg/generated/clientset/versioned"
+	"github.com/k8snetworkplumbingwg/whereabouts/pkg/ipamclaim"
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/iphelpers"
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/logging"
 	"github.com/k8snetworkplumbingwg/whereabouts/pkg/storage"
@@ -251,7 +252,13 @@ func toIPReservationList(allocations map[string]whereaboutsv1alpha1.IPAllocation
 			continue
 		}
 		ip := iphelpers.IPAddOffset(firstip, uint64(numOffset))
-		reservelist = append(reservelist, whereaboutstypes.IPReservation{IP: ip, ContainerID: a.ContainerID, PodRef: a.PodRef, IfName: a.IfName})
+		reservelist = append(reservelist, whereaboutstypes.IPReservation{
+			IP:           ip,
+			ContainerID:  a.ContainerID,
+			PodRef:       a.PodRef,
+			IfName:       a.IfName,
+			IPAMClaimRef: a.IPAMClaimRef,
+		})
 	}
 	return reservelist
 }
@@ -263,7 +270,12 @@ func toAllocationMap(reservelist []whereaboutstypes.IPReservation, firstip net.I
 		if err != nil {
 			return nil, err
 		}
-		allocations[fmt.Sprintf("%d", index)] = whereaboutsv1alpha1.IPAllocation{ContainerID: r.ContainerID, PodRef: r.PodRef, IfName: r.IfName}
+		allocations[fmt.Sprintf("%d", index)] = whereaboutsv1alpha1.IPAllocation{
+			ContainerID:  r.ContainerID,
+			PodRef:       r.PodRef,
+			IfName:       r.IfName,
+			IPAMClaimRef: r.IPAMClaimRef,
+		}
 	}
 	return allocations, nil
 }
@@ -305,7 +317,7 @@ func (c *KubernetesOverlappingRangeStore) GetOverlappingRangeIPReservation(ctx c
 
 // UpdateOverlappingRangeAllocation updates clusterwide allocation for overlapping ranges.
 func (c *KubernetesOverlappingRangeStore) UpdateOverlappingRangeAllocation(ctx context.Context, mode int, ip net.IP,
-	podRef, ifName, networkName string) error {
+	podRef, ifName, networkName, claimRef string) error {
 	normalizedIP := NormalizeIP(ip, networkName)
 
 	clusteripres := &whereaboutsv1alpha1.OverlappingRangeIPReservation{
@@ -320,12 +332,28 @@ func (c *KubernetesOverlappingRangeStore) UpdateOverlappingRangeAllocation(ctx c
 		verb = "allocate"
 
 		clusteripres.Spec = whereaboutsv1alpha1.OverlappingRangeIPReservationSpec{
-			PodRef: podRef,
-			IfName: ifName,
+			PodRef:       podRef,
+			IfName:       ifName,
+			IPAMClaimRef: claimRef,
 		}
 
 		_, err = c.client.WhereaboutsV1alpha1().OverlappingRangeIPReservations(c.namespace).Create(
 			ctx, clusteripres, metav1.CreateOptions{})
+		if err != nil && errors.IsAlreadyExists(err) {
+			// Claim take-over (or idempotent retry): refresh PodRef / IfName / claim on the
+			// existing overlapping reservation instead of failing create.
+			existing, getErr := c.client.WhereaboutsV1alpha1().OverlappingRangeIPReservations(c.namespace).Get(
+				ctx, normalizedIP, metav1.GetOptions{})
+			if getErr != nil {
+				return getErr
+			}
+			existing.Spec.PodRef = podRef
+			existing.Spec.IfName = ifName
+			existing.Spec.IPAMClaimRef = claimRef
+			_, err = c.client.WhereaboutsV1alpha1().OverlappingRangeIPReservations(c.namespace).Update(
+				ctx, existing, metav1.UpdateOptions{})
+			verb = "update"
+		}
 
 	case whereaboutstypes.Deallocate:
 		verb = "deallocate"
@@ -566,6 +594,26 @@ func IPManagementKubernetesUpdate(ctx context.Context, mode int, ipam *Kubernete
 		return newips, err
 	}
 
+	if mode == whereaboutstypes.Allocate {
+		if err := ipamclaim.ResolveFromPodAnnotation(requestCtx, ipam.clientSet, &ipamConf, ipam.IfName); err != nil {
+			logging.Errorf("IPAMClaim resolution from pod annotation failed: %v", err)
+			return newips, err
+		}
+		ipam.Config = ipamConf
+	}
+
+	var preferredClaimIPs []net.IP
+	claimRef := ipamConf.GetIPAMClaimRef()
+	if mode == whereaboutstypes.Allocate && ipamConf.HasIPAMClaim() {
+		claim, err := ipamclaim.GetClaim(requestCtx, ipam.ipamClaimsClient, ipamConf)
+		if err != nil {
+			logging.Errorf("Failed to get IPAMClaim %s: %v", claimRef, err)
+			return newips, err
+		}
+		preferredClaimIPs = ipamclaim.ParseClaimIPs(claim)
+		logging.Debugf("IPAMClaim %s preferred IPs: %v", claimRef, preferredClaimIPs)
+	}
+
 	// handle the ip add/del until successful
 	var overlappingrangeallocations []whereaboutstypes.IPReservation
 	var ipforoverlappingrangeupdate net.IP
@@ -633,7 +681,7 @@ func IPManagementKubernetesUpdate(ctx context.Context, mode int, ipam *Kubernete
 			var updatedreservelist []whereaboutstypes.IPReservation
 			switch mode {
 			case whereaboutstypes.Allocate:
-				newip, updatedreservelist, err = allocate.AssignIP(ipRange, reservelist, ipam.ContainerID, ipamConf.GetPodRef(), ipam.IfName)
+				newip, updatedreservelist, err = allocate.AssignIPForClaim(ipRange, reservelist, ipam.ContainerID, ipamConf.GetPodRef(), ipam.IfName, claimRef, preferredClaimIPs)
 				if err != nil {
 					logging.Errorf("Error assigning IP: %v", err)
 					return newips, err
@@ -650,20 +698,40 @@ func IPManagementKubernetesUpdate(ctx context.Context, mode int, ipam *Kubernete
 					}
 
 					if overlappingRangeIPReservation != nil {
-						if overlappingRangeIPReservation.Spec.PodRef != ipamConf.GetPodRef() {
+						samePod := overlappingRangeIPReservation.Spec.PodRef == ipamConf.GetPodRef()
+						sameClaim := claimRef != "" && overlappingRangeIPReservation.Spec.IPAMClaimRef == claimRef
+						if !samePod && !sameClaim {
 							logging.Debugf("Continuing loop, IP is already allocated (possibly from another range): %v", newip)
 							// We create "dummy" records here for evaluation, but, we need to filter those out later.
 							overlappingrangeallocations = append(overlappingrangeallocations, whereaboutstypes.IPReservation{IP: newip.IP, IsAllocated: true})
 							continue
 						}
 
-						skipOverlappingRangeUpdate = true
+						// Same pod: overlapping reservation already matches; no rewrite needed.
+						// Same claim / different pod: refresh PodRef (and related fields) on take-over.
+						if samePod {
+							skipOverlappingRangeUpdate = true
+						}
 					}
 
 					ipforoverlappingrangeupdate = newip.IP
 				}
 
 			case whereaboutstypes.Deallocate:
+				// Claim-backed allocations survive pod DEL; release happens when the
+				// IPAMClaim is deleted (control-loop, follow-up PR).
+				if claimRef == "" {
+					for _, r := range reservelist {
+						if r.ContainerID == ipam.ContainerID && r.IfName == ipam.IfName && r.IPAMClaimRef != "" {
+							claimRef = r.IPAMClaimRef
+							break
+						}
+					}
+				}
+				if claimRef != "" {
+					logging.Debugf("Skipping deallocate for claim-backed allocation %q (containerID %q)", claimRef, ipam.ContainerID)
+					return newips, nil
+				}
 				updatedreservelist, ipforoverlappingrangeupdate = allocate.DeallocateIP(reservelist, ipam.ContainerID, ipam.IfName)
 				if ipforoverlappingrangeupdate == nil {
 					// Do not fail if allocation was not found.
@@ -699,7 +767,7 @@ func IPManagementKubernetesUpdate(ctx context.Context, mode int, ipam *Kubernete
 		if ipamConf.OverlappingRanges {
 			if !skipOverlappingRangeUpdate {
 				err = overlappingrangestore.UpdateOverlappingRangeAllocation(requestCtx, mode, ipforoverlappingrangeupdate,
-					ipamConf.GetPodRef(), ipam.IfName, ipamConf.NetworkName)
+					ipamConf.GetPodRef(), ipam.IfName, ipamConf.NetworkName, claimRef)
 				if err != nil {
 					logging.Errorf("Error performing UpdateOverlappingRangeAllocation: %v", err)
 					return newips, err
@@ -709,6 +777,20 @@ func IPManagementKubernetesUpdate(ctx context.Context, mode int, ipam *Kubernete
 
 		newips = append(newips, newip)
 	}
+
+	if mode == whereaboutstypes.Allocate && ipamConf.HasIPAMClaim() && len(preferredClaimIPs) == 0 {
+		if err := ipamclaim.PersistClaimIPs(requestCtx, ipam.ipamClaimsClient, ipamConf, newips); err != nil {
+			logging.Errorf("Failed to persist IPs on IPAMClaim %s: %v", claimRef, err)
+			return newips, err
+		}
+	} else if mode == whereaboutstypes.Allocate && ipamConf.HasIPAMClaim() {
+		// Reuse path: still refresh ownerPod on the claim.
+		if err := ipamclaim.PersistClaimIPs(requestCtx, ipam.ipamClaimsClient, ipamConf, newips); err != nil {
+			logging.Errorf("Failed to update ownerPod on IPAMClaim %s: %v", claimRef, err)
+			return newips, err
+		}
+	}
+
 	return newips, err
 }
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -35,7 +35,7 @@ type Store interface {
 // OverlappingRangeStore is an interface for wrapping overlappingrange storage options
 type OverlappingRangeStore interface {
 	GetOverlappingRangeIPReservation(ctx context.Context, ip net.IP, podRef, networkName string) (*v1alpha1.OverlappingRangeIPReservation, error)
-	UpdateOverlappingRangeAllocation(ctx context.Context, mode int, ip net.IP, podRef, ifName, networkName string) error
+	UpdateOverlappingRangeAllocation(ctx context.Context, mode int, ip net.IP, podRef, ifName, networkName, claimRef string) error
 }
 
 type Temporary interface {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -24,9 +24,17 @@ const (
 // Net is The top-level network config - IPAM plugins are passed the full configuration
 // of the calling plugin, not just the IPAM section.
 type Net struct {
-	Name       string      `json:"name"`
-	CNIVersion string      `json:"cniVersion"`
-	IPAM       *IPAMConfig `json:"ipam"`
+	Name               string      `json:"name"`
+	CNIVersion         string      `json:"cniVersion"`
+	IPAM               *IPAMConfig `json:"ipam"`
+	IPAMClaimReference string      `json:"ipam-claim-reference,omitempty"`
+	Args               *CNINetArgs `json:"args,omitempty"`
+}
+
+// CNINetArgs carries optional CNI args Multus may inject from network-selection
+// element cni-args (args.cni).
+type CNINetArgs struct {
+	CNI *map[string]interface{} `json:"cni,omitempty"`
 }
 
 // NetConfList describes an ordered list of networks.
@@ -73,6 +81,14 @@ type IPAMConfig struct {
 	PodName                  string
 	PodNamespace             string
 	NetworkName              string `json:"network_name,omitempty"`
+	// IPAMClaimReference is the name of an IPAMClaim that owns this allocation.
+	// Empty means legacy pod-scoped behavior. Populated from CNI config / args;
+	// production Multus+ipam-extensions flows may also resolve it from the pod's
+	// network-selection element (see pkg/ipamclaim).
+	IPAMClaimReference string `json:"ipam-claim-reference,omitempty"`
+	// IPAMClaimNamespace is the namespace of the IPAMClaim. Defaults to PodNamespace
+	// when a claim reference is set and this field is empty.
+	IPAMClaimNamespace string `json:"ipam-claim-namespace,omitempty"`
 }
 
 func (ic *IPAMConfig) UnmarshalJSON(data []byte) error {
@@ -110,6 +126,8 @@ func (ic *IPAMConfig) UnmarshalJSON(data []byte) error {
 		PodName                  string
 		PodNamespace             string
 		NetworkName              string `json:"network_name,omitempty"`
+		IPAMClaimReference       string `json:"ipam-claim-reference,omitempty"`
+		IPAMClaimNamespace       string `json:"ipam-claim-namespace,omitempty"`
 	}
 
 	ipamConfigAlias := IPAMConfigAlias{
@@ -147,12 +165,32 @@ func (ic *IPAMConfig) UnmarshalJSON(data []byte) error {
 		PodName:                  ipamConfigAlias.PodName,
 		PodNamespace:             ipamConfigAlias.PodNamespace,
 		NetworkName:              ipamConfigAlias.NetworkName,
+		IPAMClaimReference:       ipamConfigAlias.IPAMClaimReference,
+		IPAMClaimNamespace:       ipamConfigAlias.IPAMClaimNamespace,
 	}
 	return nil
 }
 
 func (ic *IPAMConfig) GetPodRef() string {
 	return fmt.Sprintf("%s/%s", ic.PodNamespace, ic.PodName)
+}
+
+// HasIPAMClaim reports whether this config is claim-backed.
+// Allocation/deallocation behavior is unchanged until later PRs honor this flag.
+func (ic *IPAMConfig) HasIPAMClaim() bool {
+	return ic != nil && ic.IPAMClaimReference != ""
+}
+
+// GetIPAMClaimRef returns "namespace/name" for the referenced IPAMClaim, or "" if unset.
+func (ic *IPAMConfig) GetIPAMClaimRef() string {
+	if !ic.HasIPAMClaim() {
+		return ""
+	}
+	ns := ic.IPAMClaimNamespace
+	if ns == "" {
+		ns = ic.PodNamespace
+	}
+	return fmt.Sprintf("%s/%s", ns, ic.IPAMClaimReference)
 }
 
 func backwardsCompatibleIPAddress(ip string) net.IP {
@@ -193,7 +231,9 @@ type IPReservation struct {
 	ContainerID string `json:"id"`
 	PodRef      string `json:"podref"`
 	IfName      string `json:"ifName"`
-	IsAllocated bool
+	// IPAMClaimRef is "namespace/name" when the reservation is claim-backed.
+	IPAMClaimRef string `json:"ipamclaimref,omitempty"`
+	IsAllocated  bool
 }
 
 func (ir IPReservation) String() string {


### PR DESCRIPTION
Reuse and retain claim-owned allocations across pod recreate, skip release on CNI DEL/GC while the claim exists and free them when the IPAMClaim is deleted. Includes RBAC/CRD install, docs and e2e coverage.

<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->

**What this PR does / why we need it**:

Adds IPAMClaim-backed persistent IPs so KubeVirt VMs can keep the same secondary IP across stop/start (pod recreate).
Whereabouts currently releases IPs on CNI DEL / GC when the virt-launcher pod goes away, so VMs often get a new address after restart. With an `IPAMClaim` (from Multus / ipam-extensions) referenced via `ipam-claim-reference`:
- Allocate reuses existing claim IPs (or assigns and persists them on `IPAMClaim.status.ips`)
- CNI DEL and reconciler/control-loop GC skip claim-backed allocations while the claim exists
- Deleting the `IPAMClaim` releases the Whereabouts pool / overlapping reservations
Also includes IPAMClaim CRD install in kind/docs/helm paths, RBAC for `ipamclaims` (+ status), user docs, and an e2e covering allocate → retain across recreate → release on claim delete.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #500 #557 

**Special notes for your reviewer** *(optional)*:

- Requires the `IPAMClaim` CRD and a claim reference on the pod network-selection annotation (Multus does not inject it into CNI stdin today, Whereabouts resolves it from the pod annotation).
- e2e covers stop/start-style recreate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent IP allocations through IPAMClaim resources.
  * IPs can now be referenced through Multus network annotations and reused across pod recreation.
  * Claim status records allocated IPs and ownership details.
  * Deleting a claim releases its associated IP reservations.
  * Added support for claim-aware allocations across standard and overlapping IP ranges.

* **Documentation**
  * Added installation guidance, configuration examples, lifecycle details, KubeVirt integration notes, and known limitations.
  * Added the IPAMClaim custom resource to deployment manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->